### PR TITLE
Add sonar properties file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=CS3213-T6-1_sqlancer
+sonar.organization=cs3213-t6-1
+sonar.host.url=https://sonarcloud.io
+sonar.token=${{ secrets.SONAR_TOKEN }}
+sonar.sources=src
+sonar.java.binaries=target/classes
+sonar.language=java
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This file is required to run the SonarQube tests in the cloud.