### PR TITLE
Add metrics.sh to calculate LCOM, Ca and Ce

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,25 @@ SQLancer has pioneered and includes multiple approaches for DBMS testing, as out
 | Differential Query Plans (DQP)                                  | SIGMOD 2024   | [Paper](https://dl.acm.org/doi/pdf/10.1145/3654991) [Video](https://www.youtube.com/watch?v=9Qp7quJfGEk) [Code](https://github.com/sqlancer/sqlancer/issues/918)   | DQP aims to find logic bugs by controlling the execution of different query plans for a given query and validating that they produce a consistent result. DQP supports MySQL, MariaDB, and TiDB.                                                                                                                                                                                                                                                                                                                                                                                                |
 | Constant Optimization Driven Database System Testing (CODDTest) | SIGMOD 2025   | [Code](https://github.com/sqlancer/sqlancer/pull/1054)                                                                                                             | CODDTest finds logic bugs in DBMSs, including in advanced features such as subqueries. It is based on the insight that we can assume the database state to be constant for a database session, which then enables us to substitute parts of a query with their results, essentially corresponding to constant folding and constant propagation, which are two traditional compiler optimizations.                                                                                                                                                                                               |
 
-Please find the `.bib` entries [here](docs/PAPERS.md).                                                                               |
+Please find the `.bib` entries [here](docs/PAPERS.md).    
+
+# Calculating metrics
+To calculate LCOM, Ca and Ce, a shell script `metrics.sh` has been written in the home directory. To run it, enter the following commends:
+
+Mac / Linux:
+
+```
+chmod a+x metrics.sh
+./metrics.sh
+```
+
+Windows:
+
+```
+git bash ./metrics.sh
+```
+
+This would generate two files that you can find in the same directory level as the `sqlancer` project.
 
 # FAQ
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Windows:
 git bash ./metrics.sh
 ```
 
-This would generate two files that you can find in the same directory level as the `sqlancer` project.
+This would generate two files `outputclass.csv` and `outputmethod.csv` that you can find in the same directory level as the `sqlancer` project. These
+files would contain the metrics LCOM, Ca and Ce that we want to find.
 
 # FAQ
 

--- a/metrics.sh
+++ b/metrics.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#1. Clone the ck repository first (to calculate metrics)
+echo "Cloning ck.."
+cd ..
+git clone https://github.com/mauricioaniche/ck
+echo "Ck cloned!"
+
+#2. Enter that repo and compile it
+echo "Compiling ck..."
+cd ck || exit
+#mvn clean compile package
+echo "Ck compiled!"
+
+#3. Run metrics test
+echo "Running metrics.."
+cd target || exit
+java -jar ck-0.7.1-SNAPSHOT-jar-with-dependencies.jar \
+    ../../sqlancer \
+    true \
+    0 \
+    false \
+    ../../output
+cd ..
+cd ..
+echo "ALL DONE!"

--- a/metrics.sh
+++ b/metrics.sh
@@ -9,7 +9,7 @@ echo "Ck cloned!"
 #2. Enter that repo and compile it
 echo "Compiling ck..."
 cd ck || exit
-#mvn clean compile package
+mvn clean compile package
 echo "Ck compiled!"
 
 #3. Run metrics test


### PR DESCRIPTION
The `metrics.sh` file is used to calculate the metrics `LCOM`, `Ca` and `Ce` using the open-source `Ck` package that can be found [here](https://github.com/mauricioaniche/ck)