### PR TITLE
Refactor ClickHouseConstant classes

### DIFF
--- a/src/sqlancer/clickhouse/ast/ClickHouseConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseConstant.java
@@ -6,7 +6,9 @@ import sqlancer.clickhouse.ast.constant.ClickHouseCreateConstant;
 
 public abstract class ClickHouseConstant extends ClickHouseExpression {
 
-    public abstract boolean isNull();
+    public boolean isNull() {
+        return false;
+    };
 
     public abstract ClickHouseConstant cast(ClickHouseDataType type);
 

--- a/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
@@ -20,6 +20,11 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
     }
 
     @Override
+    public Object getValue() {
+        return value;
+    }
+
+    @Override
     public ClickHouseConstant applyLess(ClickHouseConstant right) {
         if (this.value instanceof Float || this.value instanceof Double) {
             return applyLessFloat(right);

--- a/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
+import sqlancer.IgnoreMeException;
 import sqlancer.clickhouse.ast.constant.ClickHouseCreateConstant;
 
 public abstract class ClickHouseNumericConstant<T extends Number> extends ClickHouseConstant {
@@ -29,6 +30,16 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
         }
         return castNumeric(type);
     }
+
+    @Override
+    public ClickHouseConstant applyLess(ClickHouseConstant right) {
+        if (this.getDataType() == right.getDataType()) {
+            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
+                    : ClickHouseCreateConstant.createFalse();
+        }
+        throw new IgnoreMeException();
+    }
+
 
     private ClickHouseConstant castNumeric(ClickHouseDataType type) {
         switch (type) {

--- a/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
@@ -25,7 +25,7 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
             return ClickHouseCreateConstant.createNullConstant();
         }
 
-        if (value instanceof BigInteger) {
+        if (this.value instanceof BigInteger) {
             return castBigInteger(type);
         }
         return castNumeric(type);
@@ -33,13 +33,34 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
 
     @Override
     public ClickHouseConstant applyLess(ClickHouseConstant right) {
+        if (this.value instanceof Float || this.value instanceof Double) {
+            return applyLessFloat(right);
+        }
+        return applyLessInt(right);
+    }
+
+    private ClickHouseConstant applyLessFloat(ClickHouseConstant right) {
+        if (this.getDataType() == right.getDataType()) {
+            return this.asDouble() < right.asDouble() ? ClickHouseCreateConstant.createTrue()
+                    : ClickHouseCreateConstant.createFalse();
+        }
+        ClickHouseConstant converted;
+        if (this.value instanceof Float) {
+            converted = right.cast(ClickHouseDataType.Float32);
+        } else {
+            converted = right.cast(ClickHouseDataType.Float64);
+        }
+        return this.asDouble() < converted.asDouble() ? ClickHouseCreateConstant.createTrue()
+                : ClickHouseCreateConstant.createFalse();
+    }
+
+    public ClickHouseConstant applyLessInt(ClickHouseConstant right) {
         if (this.getDataType() == right.getDataType()) {
             return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
                     : ClickHouseCreateConstant.createFalse();
         }
         throw new IgnoreMeException();
     }
-
 
     private ClickHouseConstant castNumeric(ClickHouseDataType type) {
         switch (type) {

--- a/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
@@ -25,6 +25,22 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
     }
 
     @Override
+    public boolean asBooleanNotNull() {
+        if (this.value instanceof BigInteger) {
+            return asBooleanNotNullBigInteger();
+        }
+        return asBooleanNotNullNumeric();
+    }
+
+    private boolean asBooleanNotNullBigInteger() {
+        return this.value != BigInteger.ZERO;
+    }
+
+    private boolean asBooleanNotNullNumeric() {
+        return this.value.doubleValue() != 0;
+    }
+
+    @Override
     public ClickHouseConstant applyLess(ClickHouseConstant right) {
         if (this.value instanceof Float || this.value instanceof Double) {
             return applyLessFloat(right);

--- a/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
@@ -20,18 +20,6 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
     }
 
     @Override
-    public ClickHouseConstant cast(ClickHouseDataType type) {
-        if (type == ClickHouseDataType.Nothing) {
-            return ClickHouseCreateConstant.createNullConstant();
-        }
-
-        if (this.value instanceof BigInteger) {
-            return castBigInteger(type);
-        }
-        return castNumeric(type);
-    }
-
-    @Override
     public ClickHouseConstant applyLess(ClickHouseConstant right) {
         if (this.value instanceof Float || this.value instanceof Double) {
             return applyLessFloat(right);
@@ -54,13 +42,26 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
                 : ClickHouseCreateConstant.createFalse();
     }
 
-    public ClickHouseConstant applyLessInt(ClickHouseConstant right) {
+    private ClickHouseConstant applyLessInt(ClickHouseConstant right) {
         if (this.getDataType() == right.getDataType()) {
             return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
                     : ClickHouseCreateConstant.createFalse();
         }
         throw new IgnoreMeException();
     }
+
+    @Override
+    public ClickHouseConstant cast(ClickHouseDataType type) {
+        if (type == ClickHouseDataType.Nothing) {
+            return ClickHouseCreateConstant.createNullConstant();
+        }
+
+        if (this.value instanceof BigInteger) {
+            return castBigInteger(type);
+        }
+        return castNumeric(type);
+    }
+
 
     private ClickHouseConstant castNumeric(ClickHouseDataType type) {
         switch (type) {

--- a/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseNumericConstant.java
@@ -62,7 +62,6 @@ public abstract class ClickHouseNumericConstant<T extends Number> extends ClickH
         return castNumeric(type);
     }
 
-
     private ClickHouseConstant castNumeric(ClickHouseDataType type) {
         switch (type) {
         case String:

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseBooleanConstant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseBooleanConstant.java
@@ -21,11 +21,6 @@ public class ClickHouseBooleanConstant extends ClickHouseConstant {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseFloat32Constant extends ClickHouseNumericConstant<Float> 
     }
 
     @Override
-    public Object getValue() {
-        return value;
-    }
-
-    @Override
     public String toString() {
         if (value == Double.POSITIVE_INFINITY) {
             return "'+Inf'";

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
@@ -37,17 +37,6 @@ public class ClickHouseFloat32Constant extends ClickHouseNumericConstant<Float> 
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asDouble() < right.asDouble() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        ClickHouseConstant converted = right.cast(ClickHouseDataType.Float32);
-        return this.asDouble() < converted.asDouble() ? ClickHouseCreateConstant.createTrue()
-                : ClickHouseCreateConstant.createFalse();
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return Float.compare(value, (float) 0) == 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
@@ -2,7 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseFloat32Constant extends ClickHouseNumericConstant<Float> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat32Constant.java
@@ -16,11 +16,6 @@ public class ClickHouseFloat32Constant extends ClickHouseNumericConstant<Float> 
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public String toString() {
         if (value == Double.POSITIVE_INFINITY) {
             return "'+Inf'";

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
@@ -16,11 +16,6 @@ public class ClickHouseFloat64Constant extends ClickHouseNumericConstant<Double>
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public String toString() {
         if (value == Double.POSITIVE_INFINITY) {
             return "'+Inf'";

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
@@ -37,17 +37,6 @@ public class ClickHouseFloat64Constant extends ClickHouseNumericConstant<Double>
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asDouble() < right.asDouble() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        ClickHouseConstant converted = right.cast(ClickHouseDataType.Float64);
-        return this.asDouble() < converted.asDouble() ? ClickHouseCreateConstant.createTrue()
-                : ClickHouseCreateConstant.createFalse();
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return Double.compare(value, 0.0) == 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseFloat64Constant extends ClickHouseNumericConstant<Double>
     }
 
     @Override
-    public Object getValue() {
-        return value;
-    }
-
-    @Override
     public String toString() {
         if (value == Double.POSITIVE_INFINITY) {
             return "'+Inf'";

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseFloat64Constant.java
@@ -2,7 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseFloat64Constant extends ClickHouseNumericConstant<Double> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseInt128Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != BigInteger.ZERO;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.Int128;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseInt128Constant extends ClickHouseNumericConstant<BigInteger> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseInt128Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != BigInteger.ZERO;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
@@ -35,15 +35,6 @@ public class ClickHouseInt128Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value.longValueExact();
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt128Constant.java
@@ -32,9 +32,4 @@ public class ClickHouseInt128Constant extends ClickHouseNumericConstant<BigInteg
         return value.longValueExact();
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
-
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseInt16Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
@@ -33,15 +33,6 @@ public class ClickHouseInt16Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
@@ -30,8 +30,4 @@ public class ClickHouseInt16Constant extends ClickHouseNumericConstant<Long> {
         return value;
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
@@ -2,8 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseInt16Constant extends ClickHouseNumericConstant<Long> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt16Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseInt16Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != 0;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.Int16;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseInt256Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != BigInteger.ZERO;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
@@ -32,9 +32,4 @@ public class ClickHouseInt256Constant extends ClickHouseNumericConstant<BigInteg
         return value.longValueExact();
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
-
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseInt256Constant extends ClickHouseNumericConstant<BigInteger> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseInt256Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != BigInteger.ZERO;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.Int256;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt256Constant.java
@@ -35,15 +35,6 @@ public class ClickHouseInt256Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value.longValueExact();
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseInt32Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != 0;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.Int32;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
@@ -2,8 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseInt32Constant extends ClickHouseNumericConstant<Long> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseInt32Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
@@ -33,15 +33,6 @@ public class ClickHouseInt32Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt32Constant.java
@@ -30,9 +30,4 @@ public class ClickHouseInt32Constant extends ClickHouseNumericConstant<Long> {
         return value;
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
-
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
@@ -32,8 +32,4 @@ public class ClickHouseInt64Constant extends ClickHouseNumericConstant<BigIntege
         return value.longValueExact();
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseInt64Constant extends ClickHouseNumericConstant<BigIntege
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != BigInteger.ZERO;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.Int64;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseInt64Constant extends ClickHouseNumericConstant<BigInteger> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseInt64Constant extends ClickHouseNumericConstant<BigIntege
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != BigInteger.ZERO;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt64Constant.java
@@ -35,15 +35,6 @@ public class ClickHouseInt64Constant extends ClickHouseNumericConstant<BigIntege
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value.longValueExact();
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseInt8Constant extends ClickHouseNumericConstant<Integer> {
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != 0;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.Int8;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseInt8Constant extends ClickHouseNumericConstant<Integer> {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
@@ -33,15 +33,6 @@ public class ClickHouseInt8Constant extends ClickHouseNumericConstant<Integer> {
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
@@ -30,8 +30,4 @@ public class ClickHouseInt8Constant extends ClickHouseNumericConstant<Integer> {
         return value;
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseInt8Constant.java
@@ -2,8 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseInt8Constant extends ClickHouseNumericConstant<Integer> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseStringConstant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseStringConstant.java
@@ -16,11 +16,6 @@ public class ClickHouseStringConstant extends ClickHouseConstant {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public Object getValue() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseUInt128Constant extends ClickHouseNumericConstant<BigInte
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != BigInteger.ZERO;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.UInt128;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
@@ -35,15 +35,6 @@ public class ClickHouseUInt128Constant extends ClickHouseNumericConstant<BigInte
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value.longValueExact();
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseUInt128Constant extends ClickHouseNumericConstant<BigInteger> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
@@ -32,8 +32,4 @@ public class ClickHouseUInt128Constant extends ClickHouseNumericConstant<BigInte
         return value.longValueExact();
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt128Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseUInt128Constant extends ClickHouseNumericConstant<BigInte
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != BigInteger.ZERO;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
@@ -33,15 +33,6 @@ public class ClickHouseUInt16Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseUInt16Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
@@ -30,9 +30,4 @@ public class ClickHouseUInt16Constant extends ClickHouseNumericConstant<Long> {
         return value;
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
-
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
@@ -2,8 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseUInt16Constant extends ClickHouseNumericConstant<Long> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt16Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseUInt16Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != 0;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.UInt16;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
@@ -35,15 +35,6 @@ public class ClickHouseUInt256Constant extends ClickHouseNumericConstant<BigInte
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value.longValueExact();
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseUInt256Constant extends ClickHouseNumericConstant<BigInteger> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseUInt256Constant extends ClickHouseNumericConstant<BigInte
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != BigInteger.ZERO;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseUInt256Constant extends ClickHouseNumericConstant<BigInte
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != BigInteger.ZERO;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.UInt256;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt256Constant.java
@@ -32,8 +32,4 @@ public class ClickHouseUInt256Constant extends ClickHouseNumericConstant<BigInte
         return value.longValueExact();
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
@@ -33,15 +33,6 @@ public class ClickHouseUInt32Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
@@ -2,8 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseUInt32Constant extends ClickHouseNumericConstant<Long> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseUInt32Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
@@ -30,8 +30,4 @@ public class ClickHouseUInt32Constant extends ClickHouseNumericConstant<Long> {
         return value;
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt32Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseUInt32Constant extends ClickHouseNumericConstant<Long> {
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != 0;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.UInt32;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseUInt64Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != BigInteger.ZERO;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.UInt64;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
@@ -4,8 +4,6 @@ import java.math.BigInteger;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseUInt64Constant extends ClickHouseNumericConstant<BigInteger> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
@@ -35,15 +35,6 @@ public class ClickHouseUInt64Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value.longValueExact();
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
@@ -32,8 +32,4 @@ public class ClickHouseUInt64Constant extends ClickHouseNumericConstant<BigInteg
         return value.longValueExact();
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt64Constant.java
@@ -13,11 +13,6 @@ public class ClickHouseUInt64Constant extends ClickHouseNumericConstant<BigInteg
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != BigInteger.ZERO;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseUInt8Constant extends ClickHouseNumericConstant<Integer> 
     }
 
     @Override
-    public boolean isNull() {
-        return false;
-    }
-
-    @Override
     public boolean asBooleanNotNull() {
         return value != 0;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
@@ -11,11 +11,6 @@ public class ClickHouseUInt8Constant extends ClickHouseNumericConstant<Integer> 
     }
 
     @Override
-    public boolean asBooleanNotNull() {
-        return value != 0;
-    }
-
-    @Override
     public ClickHouseDataType getDataType() {
         return ClickHouseDataType.UInt8;
     }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
@@ -30,9 +30,4 @@ public class ClickHouseUInt8Constant extends ClickHouseNumericConstant<Integer> 
         return value;
     }
 
-    @Override
-    public Object getValue() {
-        return value;
-    }
-
 }

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
@@ -2,8 +2,6 @@ package sqlancer.clickhouse.ast.constant;
 
 import com.clickhouse.client.ClickHouseDataType;
 
-import sqlancer.IgnoreMeException;
-import sqlancer.clickhouse.ast.ClickHouseConstant;
 import sqlancer.clickhouse.ast.ClickHouseNumericConstant;
 
 public class ClickHouseUInt8Constant extends ClickHouseNumericConstant<Integer> {

--- a/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
+++ b/src/sqlancer/clickhouse/ast/constant/ClickHouseUInt8Constant.java
@@ -33,15 +33,6 @@ public class ClickHouseUInt8Constant extends ClickHouseNumericConstant<Integer> 
     }
 
     @Override
-    public ClickHouseConstant applyLess(ClickHouseConstant right) {
-        if (this.getDataType() == right.getDataType()) {
-            return this.asInt() < right.asInt() ? ClickHouseCreateConstant.createTrue()
-                    : ClickHouseCreateConstant.createFalse();
-        }
-        throw new IgnoreMeException();
-    }
-
-    @Override
     public long asInt() {
         return value;
     }


### PR DESCRIPTION
Moved the method applyLess() from the ClickHouseConstant (Int, Uint, Float) subclasses classes into the superclass ClickHouseConstantNumeric.

Moved the method isNull() to ClickHouseConstant class. (Except from the ClickHouseNullConstant class).

Moved the method getValue() from all ClickHouseConstant classes except ClickHouseBooleanConstant and ClickHouseNullConstant into superclass ClickHouseConstantNumeric.

Move the method asBooleanNotNull from ClickHouseConstant (Int, Uint) subclasses into the superclass ClickHouseConstantNumeric.

