### PR TITLE
Reduce oracle duplication

### DIFF
--- a/src/sqlancer/citus/oracle/tlp/CitusTLPBase.java
+++ b/src/sqlancer/citus/oracle/tlp/CitusTLPBase.java
@@ -1,5 +1,7 @@
 package sqlancer.citus.oracle.tlp;
 
+import static sqlancer.postgres.PostgresUtils.createSubquery;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/sqlancer/cockroachdb/CockroachDBUtils.java
+++ b/src/sqlancer/cockroachdb/CockroachDBUtils.java
@@ -1,0 +1,25 @@
+package sqlancer.cockroachdb;
+
+import sqlancer.cockroachdb.ast.CockroachDBJoin;
+import sqlancer.common.ast.JoinBase.JoinType;
+
+public class CockroachDBUtils {
+
+    public static boolean selectAndSetNewJoinType(CockroachDBJoin join, JoinType newJoinType) {
+        if (join.getJoinType() == JoinType.LEFT || join.getJoinType() == JoinType.RIGHT) { // No invariant relation
+            // between LEFT and RIGHT
+            // join
+            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS,
+                    JoinType.LEFT, JoinType.RIGHT);
+        } else if (join.getJoinType() == JoinType.FULL) {
+            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS);
+        } else if (join.getJoinType() != JoinType.CROSS) {
+            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, join.getJoinType());
+        }
+        assert newJoinType != JoinType.NATURAL; // Natural Join is not supported for CERT
+        boolean increase = join.getJoinType().ordinal() < newJoinType.ordinal();
+        join.setJoinType(newJoinType);
+        return increase;
+    }
+
+}

--- a/src/sqlancer/cockroachdb/CockroachDBUtils.java
+++ b/src/sqlancer/cockroachdb/CockroachDBUtils.java
@@ -5,7 +5,6 @@ import sqlancer.common.ast.JoinBase.JoinType;
 
 public final class CockroachDBUtils {
 
-
     private CockroachDBUtils() {
     }
 
@@ -17,9 +16,11 @@ public final class CockroachDBUtils {
             selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS,
                     JoinType.LEFT, JoinType.RIGHT);
         } else if (join.getJoinType() == JoinType.FULL) {
-            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS);
+            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL,
+                    JoinType.CROSS);
         } else if (join.getJoinType() != JoinType.CROSS) {
-            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, join.getJoinType());
+            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL,
+                    join.getJoinType());
         }
 
         assert selectedJoinType != JoinType.NATURAL; // Natural Join is not supported for CERT

--- a/src/sqlancer/cockroachdb/CockroachDBUtils.java
+++ b/src/sqlancer/cockroachdb/CockroachDBUtils.java
@@ -3,23 +3,28 @@ package sqlancer.cockroachdb;
 import sqlancer.cockroachdb.ast.CockroachDBJoin;
 import sqlancer.common.ast.JoinBase.JoinType;
 
-public class CockroachDBUtils {
+public final class CockroachDBUtils {
 
-    public static boolean selectAndSetNewJoinType(CockroachDBJoin join, JoinType newJoinType) {
-        if (join.getJoinType() == JoinType.LEFT || join.getJoinType() == JoinType.RIGHT) { // No invariant relation
-            // between LEFT and RIGHT
-            // join
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS,
-                    JoinType.LEFT, JoinType.RIGHT);
-        } else if (join.getJoinType() == JoinType.FULL) {
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS);
-        } else if (join.getJoinType() != JoinType.CROSS) {
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, join.getJoinType());
-        }
-        assert newJoinType != JoinType.NATURAL; // Natural Join is not supported for CERT
-        boolean increase = join.getJoinType().ordinal() < newJoinType.ordinal();
-        join.setJoinType(newJoinType);
-        return increase;
+
+    private CockroachDBUtils() {
     }
 
+    public static boolean selectAndSetNewJoinType(CockroachDBJoin join, JoinType unusedJoinType) {
+        JoinType selectedJoinType = unusedJoinType; // Start with the passed value
+
+        if (join.getJoinType() == JoinType.LEFT || join.getJoinType() == JoinType.RIGHT) { // No invariant relation
+            // between LEFT and RIGHT join
+            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS,
+                    JoinType.LEFT, JoinType.RIGHT);
+        } else if (join.getJoinType() == JoinType.FULL) {
+            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS);
+        } else if (join.getJoinType() != JoinType.CROSS) {
+            selectedJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, join.getJoinType());
+        }
+
+        assert selectedJoinType != JoinType.NATURAL; // Natural Join is not supported for CERT
+        boolean increase = join.getJoinType().ordinal() < selectedJoinType.ordinal();
+        join.setJoinType(selectedJoinType);
+        return increase;
+    }
 }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBExpressionGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBExpressionGenerator.java
@@ -1,5 +1,7 @@
 package sqlancer.cockroachdb.gen;
 
+import static sqlancer.cockroachdb.CockroachDBUtils.selectAndSetNewJoinType;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -509,20 +511,7 @@ public class CockroachDBExpressionGenerator extends
         }
 
         JoinType newJoinType = CockroachDBJoin.JoinType.INNER;
-        if (join.getJoinType() == JoinType.LEFT || join.getJoinType() == JoinType.RIGHT) { // No invariant relation
-                                                                                           // between LEFT and RIGHT
-                                                                                           // join
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS,
-                    JoinType.LEFT, JoinType.RIGHT);
-        } else if (join.getJoinType() == JoinType.FULL) {
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS);
-        } else if (join.getJoinType() != JoinType.CROSS) {
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, join.getJoinType());
-        }
-        assert newJoinType != JoinType.NATURAL; // Natural Join is not supported for CERT
-        boolean increase = join.getJoinType().ordinal() < newJoinType.ordinal();
-        join.setJoinType(newJoinType);
-        return increase;
+        return selectAndSetNewJoinType(join, newJoinType);
     }
 
     boolean mutateDistinct(CockroachDBSelect select) {

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBCERTOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBCERTOracle.java
@@ -1,8 +1,8 @@
 package sqlancer.cockroachdb.oracle;
 
 import static sqlancer.cockroachdb.CockroachDBUtils.selectAndSetNewJoinType;
+import static sqlancer.common.oracle.TestOracleUtils.logQueryIfEnabled;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -234,16 +234,8 @@ public class CockroachDBCERTOracle extends CERTOracleBase<CockroachDBGlobalState
         String explainQuery = "EXPLAIN " + selectStr;
 
         // Log the query
-        if (globalState.getOptions().logEachSelect()) {
-            globalState.getLogger().writeCurrent(explainQuery);
-            try {
-                globalState.getLogger().getCurrentFileWriter().flush();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
+        logQueryIfEnabled(globalState, explainQuery);
 
-        // Get the row count
         SQLQueryAdapter q = new SQLQueryAdapter(explainQuery, errors);
         try (SQLancerResultSet rs = q.executeAndGet(globalState)) {
             if (rs != null) {

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBCERTOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBCERTOracle.java
@@ -1,5 +1,7 @@
 package sqlancer.cockroachdb.oracle;
 
+import static sqlancer.cockroachdb.CockroachDBUtils.selectAndSetNewJoinType;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -141,20 +143,7 @@ public class CockroachDBCERTOracle extends CERTOracleBase<CockroachDBGlobalState
         }
 
         JoinType newJoinType = CockroachDBJoin.JoinType.INNER;
-        if (join.getJoinType() == JoinType.LEFT || join.getJoinType() == JoinType.RIGHT) { // No invariant relation
-                                                                                           // between LEFT and RIGHT
-                                                                                           // join
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS,
-                    JoinType.LEFT, JoinType.RIGHT);
-        } else if (join.getJoinType() == JoinType.FULL) {
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, JoinType.CROSS);
-        } else if (join.getJoinType() != JoinType.CROSS) {
-            newJoinType = CockroachDBJoin.JoinType.getRandomExcept("COCKROACHDB", JoinType.NATURAL, join.getJoinType());
-        }
-        assert newJoinType != JoinType.NATURAL; // Natural Join is not supported for CERT
-        boolean increase = join.getJoinType().ordinal() < newJoinType.ordinal();
-        join.setJoinType(newJoinType);
-        return increase;
+        return selectAndSetNewJoinType(join, newJoinType);
     }
 
     @Override

--- a/src/sqlancer/common/oracle/CERTOracle.java
+++ b/src/sqlancer/common/oracle/CERTOracle.java
@@ -1,6 +1,7 @@
 package sqlancer.common.oracle;
 
-import java.io.IOException;
+import static sqlancer.common.oracle.TestOracleUtils.logQueryIfEnabled;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -96,14 +97,7 @@ public class CERTOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E
         Optional<Long> row = Optional.empty();
 
         // Log the query
-        if (globalState.getOptions().logEachSelect()) {
-            globalState.getLogger().writeCurrent(explainQuery);
-            try {
-                globalState.getLogger().getCurrentFileWriter().flush();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
+        logQueryIfEnabled(globalState, explainQuery);
 
         // Get the row count
         SQLQueryAdapter q = new SQLQueryAdapter(explainQuery, errors);

--- a/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
+++ b/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
@@ -10,6 +10,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.common.schema.AbstractRowValue;
+import sqlancer.common.schema.AbstractTableColumn;
 
 public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?, C>, R extends AbstractRowValue<?, ?, ?>, E, C extends SQLancerDBConnection>
         implements TestOracle<S> {
@@ -135,4 +136,20 @@ public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?, C>, 
      */
     protected abstract String getExpectedValues(E expr);
 
+    protected StringBuilder appendColumn(StringBuilder sb, Boolean isNull, String textRepresentation, int index,
+            AbstractTableColumn<?, ?> c) {
+        if (index > 0) {
+            sb.append(" AND ");
+        }
+        sb.append("result.");
+        sb.append(c.getTable().getName());
+        sb.append(c.getName());
+        if (isNull) {
+            sb.append(" IS NULL");
+        } else {
+            sb.append(" = ");
+            sb.append(textRepresentation);
+        }
+        return sb;
+    }
 }

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -1,7 +1,10 @@
 package sqlancer.common.oracle;
 
+import java.io.IOException;
+
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
+import sqlancer.SQLGlobalState;
 import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.gen.PartitionGenerator;
 import sqlancer.common.schema.AbstractSchema;
@@ -51,5 +54,17 @@ public final class TestOracleUtils {
             throw new IllegalStateException();
         }
         return new PredicateVariants<>(predicate, negatedPredicate, isNullPredicate);
+    }
+
+    public static void logQueryIfEnabled(SQLGlobalState<?, ?> globalState, String explainQuery) {
+        // Log the query
+        if (globalState.getOptions().logEachSelect()) {
+            globalState.getLogger().writeCurrent(explainQuery);
+            try {
+                globalState.getLogger().getCurrentFileWriter().flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -75,7 +75,7 @@ public final class TestOracleUtils {
         }
     }
 
-    public static String executeQuery(SQLGlobalState<?, ?> state, String queryString, ExpectedErrors errors)
+    public static String getAggregateResult(SQLGlobalState<?, ?> state, String queryString, ExpectedErrors errors)
             throws SQLException {
 
         // Log the query if enabled
@@ -100,9 +100,12 @@ public final class TestOracleUtils {
         return resultString;
     }
 
-    @SuppressWarnings("PMD.UseObjectForClearerAPI")
-    public static void executeAndCompareQueries(SQLGlobalState<?, ?> state, String originalQuery, String firstResult,
-            String metamorphicQuery, String secondResult) throws SQLException {
+    public static void executeAndCompareQueries(SQLGlobalState<?, ?> state, String originalQuery,
+            String metamorphicQuery, ExpectedErrors errors) throws SQLException {
+
+        // Execute both queries
+        String firstResult = getAggregateResult(state, originalQuery, errors);
+        String secondResult = getAggregateResult(state, metamorphicQuery, errors);
 
         // Format and log the queries and their results
         String queryFormatString = "-- %s;\n-- result: %s";

--- a/src/sqlancer/databend/test/DatabendPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/databend/test/DatabendPivotedQuerySynthesisOracle.java
@@ -93,18 +93,8 @@ public class DatabendPivotedQuerySynthesisOracle
         sb.append(") as result WHERE ");
         int i = 0;
         for (DatabendColumn c : fetchColumns) {
-            if (i++ != 0) {
-                sb.append(" AND ");
-            }
-            sb.append("result.");
-            sb.append(c.getTable().getName());
-            sb.append(c.getName());
-            if (pivotRow.getValues().get(c).isNull()) {
-                sb.append(" IS NULL ");
-            } else {
-                sb.append(" = ");
-                sb.append(pivotRow.getValues().get(c).toString());
-            }
+            sb = appendColumn(sb, pivotRow.getValues().get(c).isNull(), pivotRow.getValues().get(c).toString(), i, c);
+            i++;
         }
         String resultingQueryString = sb.toString();
         return new SQLQueryAdapter(resultingQueryString, errors);

--- a/src/sqlancer/doris/oracle/DorisPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/doris/oracle/DorisPivotedQuerySynthesisOracle.java
@@ -95,18 +95,8 @@ public class DorisPivotedQuerySynthesisOracle
         sb.append(") as result WHERE ");
         int i = 0;
         for (DorisColumn c : fetchColumns) {
-            if (i++ != 0) {
-                sb.append(" AND ");
-            }
-            sb.append("result.");
-            sb.append(c.getTable().getName());
-            sb.append(c.getName());
-            if (pivotRow.getValues().get(c).isNull()) {
-                sb.append(" IS NULL ");
-            } else {
-                sb.append(" = ");
-                sb.append(pivotRow.getValues().get(c).toString());
-            }
+            sb = appendColumn(sb, pivotRow.getValues().get(c).isNull(), pivotRow.getValues().get(c).toString(), i, c);
+            i++;
         }
         String resultingQueryString = sb.toString();
         return new SQLQueryAdapter(resultingQueryString, errors);

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningBase.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningBase.java
@@ -23,6 +23,7 @@ import sqlancer.doris.ast.DorisJoin;
 import sqlancer.doris.ast.DorisSelect;
 import sqlancer.doris.ast.DorisTableReference;
 import sqlancer.doris.gen.DorisNewExpressionGenerator;
+import sqlancer.doris.visitor.DorisToStringVisitor;
 
 public class DorisQueryPartitioningBase extends TernaryLogicPartitioningOracleBase<DorisExpression, DorisGlobalState>
         implements TestOracle<DorisGlobalState> {
@@ -77,6 +78,21 @@ public class DorisQueryPartitioningBase extends TernaryLogicPartitioningOracleBa
     @Override
     protected ExpressionGenerator<DorisExpression> getGen() {
         return gen;
+    }
+
+    protected List<String> getQueryStrings(DorisSelect select) throws SQLException {
+        List<String> queryStrings = new ArrayList<>();
+        select.setWhereClause(predicate);
+        String firstQueryString = DorisToStringVisitor.asString(select);
+        queryStrings.add(firstQueryString);
+        select.setWhereClause(negatedPredicate);
+        String secondQueryString = DorisToStringVisitor.asString(select);
+        queryStrings.add(secondQueryString);
+        select.setWhereClause(isNullPredicate);
+        String thirdQueryString = DorisToStringVisitor.asString(select);
+        queryStrings.add(thirdQueryString);
+
+        return queryStrings;
     }
 
 }

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningDistinctTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningDistinctTester.java
@@ -25,12 +25,10 @@ public class DorisQueryPartitioningDistinctTester extends DorisQueryPartitioning
         String originalQueryString = DorisToStringVisitor.asString(select);
         List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
 
-        select.setWhereClause(predicate);
-        String firstQueryString = DorisToStringVisitor.asString(select);
-        select.setWhereClause(negatedPredicate);
-        String secondQueryString = DorisToStringVisitor.asString(select);
-        select.setWhereClause(isNullPredicate);
-        String thirdQueryString = DorisToStringVisitor.asString(select);
+        List<String> queryStrings = getQueryStrings(select);
+        String firstQueryString = queryStrings.get(0);
+        String secondQueryString = queryStrings.get(1);
+        String thirdQueryString = queryStrings.get(2);
         List<String> combinedString = new ArrayList<>();
 
         String unionString = "SELECT DISTINCT * FROM (" + firstQueryString + " UNION ALL " + secondQueryString

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningGroupByTester.java
@@ -27,18 +27,12 @@ public class DorisQueryPartitioningGroupByTester extends DorisQueryPartitioningB
         select.setGroupByExpressions(select.getFetchColumns());
         select.setWhereClause(null);
         String originalQueryString = DorisToStringVisitor.asString(select);
-
         List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
-
-        select.setWhereClause(predicate);
-        String firstQueryString = DorisToStringVisitor.asString(select);
-        select.setWhereClause(negatedPredicate);
-        String secondQueryString = DorisToStringVisitor.asString(select);
-        select.setWhereClause(isNullPredicate);
-        String thirdQueryString = DorisToStringVisitor.asString(select);
+        List<String> queryStrings = getQueryStrings(select);
         List<String> combinedString = new ArrayList<>();
-        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
-                secondQueryString, thirdQueryString, combinedString, true, state, errors);
+
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(queryStrings.get(0),
+                queryStrings.get(1), queryStrings.get(2), combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
                 state, ComparatorHelper::canonicalizeResultValue);
     }

--- a/src/sqlancer/materialize/MaterializeUtils.java
+++ b/src/sqlancer/materialize/MaterializeUtils.java
@@ -8,14 +8,14 @@ import java.util.List;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.ast.JoinBase.JoinType;
-import sqlancer.materialize.ast.MaterializeExpression;
-import sqlancer.materialize.ast.MaterializeJoin;
-import sqlancer.materialize.ast.MaterializeSelect.MaterializeFromTable;
-import sqlancer.materialize.ast.MaterializeSelect.MaterializeSubquery;
 import sqlancer.materialize.MaterializeSchema.MaterializeColumn;
 import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
 import sqlancer.materialize.MaterializeSchema.MaterializeTable;
 import sqlancer.materialize.MaterializeSchema.MaterializeTables;
+import sqlancer.materialize.ast.MaterializeExpression;
+import sqlancer.materialize.ast.MaterializeJoin;
+import sqlancer.materialize.ast.MaterializeSelect.MaterializeFromTable;
+import sqlancer.materialize.ast.MaterializeSelect.MaterializeSubquery;
 import sqlancer.materialize.gen.MaterializeExpressionGenerator;
 
 public final class MaterializeUtils {

--- a/src/sqlancer/materialize/MaterializeUtils.java
+++ b/src/sqlancer/materialize/MaterializeUtils.java
@@ -1,0 +1,51 @@
+package sqlancer.materialize;
+
+import static sqlancer.materialize.oracle.tlp.MaterializeTLPBase.createSubquery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.JoinBase;
+import sqlancer.common.ast.JoinBase.JoinType;
+import sqlancer.materialize.ast.MaterializeExpression;
+import sqlancer.materialize.ast.MaterializeJoin;
+import sqlancer.materialize.ast.MaterializeSelect.MaterializeFromTable;
+import sqlancer.materialize.ast.MaterializeSelect.MaterializeSubquery;
+import sqlancer.materialize.gen.MaterializeExpressionGenerator;
+import sqlancer.materialize.MaterializeSchema.MaterializeColumn;
+import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
+import sqlancer.materialize.MaterializeSchema.MaterializeTable;
+import sqlancer.materialize.MaterializeSchema.MaterializeTables;
+
+public final class MaterializeUtils {
+
+    private MaterializeUtils() {
+    }
+
+    public static List<MaterializeJoin> getJoinStatements(MaterializeGlobalState globalState,
+            List<MaterializeColumn> columns, List<MaterializeTable> tables) {
+        List<MaterializeJoin> joinStatements = new ArrayList<>();
+        MaterializeExpressionGenerator gen = new MaterializeExpressionGenerator(globalState).setColumns(columns);
+        for (int i = 1; i < tables.size(); i++) {
+            MaterializeExpression joinClause = gen.generateExpression(MaterializeDataType.BOOLEAN);
+            MaterializeTable table = Randomly.fromList(tables);
+            tables.remove(table);
+            JoinBase.JoinType options = JoinBase.JoinType.getRandom();
+            MaterializeJoin j = new MaterializeJoin(new MaterializeFromTable(table, Randomly.getBoolean()), joinClause,
+                    options);
+            joinStatements.add(j);
+        }
+        // JOIN subqueries
+        for (int i = 0; i < Randomly.smallNumber(); i++) {
+            MaterializeTables subqueryTables = globalState.getSchema().getRandomTableNonEmptyTables();
+            MaterializeSubquery subquery = createSubquery(globalState, String.format("sub%d", i), subqueryTables);
+            MaterializeExpression joinClause = gen.generateExpression(MaterializeDataType.BOOLEAN);
+            JoinType options = JoinType.getRandom();
+            MaterializeJoin j = new MaterializeJoin(subquery, joinClause, options);
+            joinStatements.add(j);
+        }
+
+        return joinStatements;
+    }
+}

--- a/src/sqlancer/materialize/MaterializeUtils.java
+++ b/src/sqlancer/materialize/MaterializeUtils.java
@@ -12,11 +12,11 @@ import sqlancer.materialize.ast.MaterializeExpression;
 import sqlancer.materialize.ast.MaterializeJoin;
 import sqlancer.materialize.ast.MaterializeSelect.MaterializeFromTable;
 import sqlancer.materialize.ast.MaterializeSelect.MaterializeSubquery;
-import sqlancer.materialize.gen.MaterializeExpressionGenerator;
 import sqlancer.materialize.MaterializeSchema.MaterializeColumn;
 import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
 import sqlancer.materialize.MaterializeSchema.MaterializeTable;
 import sqlancer.materialize.MaterializeSchema.MaterializeTables;
+import sqlancer.materialize.gen.MaterializeExpressionGenerator;
 
 public final class MaterializeUtils {
 

--- a/src/sqlancer/materialize/gen/MaterializeExpressionGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeExpressionGenerator.java
@@ -1,5 +1,7 @@
 package sqlancer.materialize.gen;
 
+import static sqlancer.materialize.MaterializeUtils.getJoinStatements;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,7 +12,6 @@ import java.util.stream.Stream;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
-import sqlancer.common.ast.JoinBase.JoinType;
 import sqlancer.common.ast.SelectBase.SelectType;
 import sqlancer.common.gen.ExpressionGenerator;
 import sqlancer.common.gen.NoRECGenerator;
@@ -23,7 +24,6 @@ import sqlancer.materialize.MaterializeSchema.MaterializeColumn;
 import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
 import sqlancer.materialize.MaterializeSchema.MaterializeRowValue;
 import sqlancer.materialize.MaterializeSchema.MaterializeTable;
-import sqlancer.materialize.MaterializeSchema.MaterializeTables;
 import sqlancer.materialize.ast.MaterializeAggregate;
 import sqlancer.materialize.ast.MaterializeAggregate.MaterializeAggregateFunction;
 import sqlancer.materialize.ast.MaterializeBetweenOperation;
@@ -56,8 +56,6 @@ import sqlancer.materialize.ast.MaterializePrefixOperation;
 import sqlancer.materialize.ast.MaterializePrefixOperation.PrefixOperator;
 import sqlancer.materialize.ast.MaterializeSelect;
 import sqlancer.materialize.ast.MaterializeSelect.MaterializeFromTable;
-import sqlancer.materialize.ast.MaterializeSelect.MaterializeSubquery;
-import sqlancer.materialize.oracle.tlp.MaterializeTLPBase;
 
 public class MaterializeExpressionGenerator implements ExpressionGenerator<MaterializeExpression>,
         NoRECGenerator<MaterializeSelect, MaterializeJoin, MaterializeExpression, MaterializeTable, MaterializeColumn>,
@@ -553,29 +551,7 @@ public class MaterializeExpressionGenerator implements ExpressionGenerator<Mater
 
     @Override
     public List<MaterializeJoin> getRandomJoinClauses() {
-        List<MaterializeJoin> joinStatements = new ArrayList<>();
-        MaterializeExpressionGenerator gen = new MaterializeExpressionGenerator(globalState).setColumns(columns);
-        for (int i = 1; i < tables.size(); i++) {
-            MaterializeExpression joinClause = gen.generateExpression(MaterializeDataType.BOOLEAN);
-            MaterializeTable table = Randomly.fromList(tables);
-            tables.remove(table);
-            JoinType options = JoinType.getRandom();
-            MaterializeJoin j = new MaterializeJoin(new MaterializeFromTable(table, Randomly.getBoolean()), joinClause,
-                    options);
-            joinStatements.add(j);
-        }
-        // JOIN subqueries
-        for (int i = 0; i < Randomly.smallNumber(); i++) {
-            MaterializeTables subqueryTables = globalState.getSchema().getRandomTableNonEmptyTables();
-            MaterializeSubquery subquery = MaterializeTLPBase.createSubquery(globalState, String.format("sub%d", i),
-                    subqueryTables);
-            MaterializeExpression joinClause = gen.generateExpression(MaterializeDataType.BOOLEAN);
-            JoinType options = JoinType.getRandom();
-            MaterializeJoin j = new MaterializeJoin(subquery, joinClause, options);
-            joinStatements.add(j);
-        }
-
-        return joinStatements;
+        return getJoinStatements(globalState, columns, tables);
     }
 
     @Override

--- a/src/sqlancer/materialize/oracle/MaterializePivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/materialize/oracle/MaterializePivotedQuerySynthesisOracle.java
@@ -126,18 +126,9 @@ public class MaterializePivotedQuerySynthesisOracle extends
         sb.append(") as result WHERE ");
         int i = 0;
         for (MaterializeColumn c : fetchColumns) {
-            if (i++ != 0) {
-                sb.append(" AND ");
-            }
-            sb.append("result.");
-            sb.append(c.getTable().getName());
-            sb.append(c.getName());
-            if (pivotRow.getValues().get(c).isNull()) {
-                sb.append(" IS NULL");
-            } else {
-                sb.append(" = ");
-                sb.append(pivotRow.getValues().get(c).getTextRepresentation());
-            }
+            sb = appendColumn(sb, pivotRow.getValues().get(c).isNull(),
+                    pivotRow.getValues().get(c).getTextRepresentation(), i, c);
+            i++;
         }
         String resultingQueryString = sb.toString();
         return new SQLQueryAdapter(resultingQueryString, errors);

--- a/src/sqlancer/materialize/oracle/tlp/MaterializeTLPAggregateOracle.java
+++ b/src/sqlancer/materialize/oracle/tlp/MaterializeTLPAggregateOracle.java
@@ -1,5 +1,6 @@
 package sqlancer.materialize.oracle.tlp;
 
+import static sqlancer.common.oracle.TestOracleUtils.executeAndCompareQueries;
 import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
 
 import java.sql.SQLException;
@@ -7,8 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.oracle.TestOracle;
@@ -67,21 +66,7 @@ public class MaterializeTLPAggregateOracle extends MaterializeTLPBase implements
         firstResult = getAggregateResult(originalQuery);
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
         secondResult = getAggregateResult(metamorphicQuery);
-
-        String queryFormatString = "-- %s;\n-- result: %s";
-        String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
-        String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
-        state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
-        if (firstResult == null && secondResult != null || firstResult != null && secondResult == null
-                || firstResult != null && !firstResult.contentEquals(secondResult)
-                        && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
-            if (secondResult != null && secondResult.contains("Inf")) {
-                throw new IgnoreMeException(); // FIXME: average computation
-            }
-            String assertionMessage = String.format("the results mismatch!\n%s\n%s", firstQueryString,
-                    secondQueryString);
-            throw new AssertionError(assertionMessage);
-        }
+        executeAndCompareQueries(state, originalQuery, firstResult, metamorphicQuery, secondResult);
     }
 
     private String createMetamorphicUnionQuery(MaterializeSelect select, MaterializeAggregate aggregate,

--- a/src/sqlancer/materialize/oracle/tlp/MaterializeTLPAggregateOracle.java
+++ b/src/sqlancer/materialize/oracle/tlp/MaterializeTLPAggregateOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.materialize.oracle.tlp;
 
 import static sqlancer.common.oracle.TestOracleUtils.executeAndCompareQueries;
-import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -28,8 +27,6 @@ import sqlancer.materialize.gen.MaterializeCommon;
 public class MaterializeTLPAggregateOracle extends MaterializeTLPBase implements TestOracle<MaterializeGlobalState> {
     private String generatedQueryString;
 
-    private String firstResult;
-    private String secondResult;
     private String originalQuery;
     private String metamorphicQuery;
 
@@ -63,10 +60,8 @@ public class MaterializeTLPAggregateOracle extends MaterializeTLPBase implements
         }
         originalQuery = MaterializeVisitor.asString(select);
         generatedQueryString = originalQuery;
-        firstResult = getAggregateResult(originalQuery);
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
-        secondResult = getAggregateResult(metamorphicQuery);
-        executeAndCompareQueries(state, originalQuery, firstResult, metamorphicQuery, secondResult);
+        executeAndCompareQueries(state, originalQuery, metamorphicQuery, errors);
     }
 
     private String createMetamorphicUnionQuery(MaterializeSelect select, MaterializeAggregate aggregate,
@@ -84,10 +79,6 @@ public class MaterializeTLPAggregateOracle extends MaterializeTLPBase implements
                 + MaterializeVisitor.asString(middleSelect) + " UNION ALL " + MaterializeVisitor.asString(rightSelect);
         metamorphicQuery += ") as asdf";
         return metamorphicQuery;
-    }
-
-    private String getAggregateResult(String queryString) throws SQLException {
-        return executeQuery(state, queryString, errors);
     }
 
     private List<MaterializeExpression> mapped(MaterializeAggregate aggregate) {

--- a/src/sqlancer/materialize/oracle/tlp/MaterializeTLPAggregateOracle.java
+++ b/src/sqlancer/materialize/oracle/tlp/MaterializeTLPAggregateOracle.java
@@ -1,20 +1,17 @@
 package sqlancer.materialize.oracle.tlp;
 
-import java.io.IOException;
+import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.postgresql.util.PSQLException;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.materialize.MaterializeGlobalState;
 import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
 import sqlancer.materialize.MaterializeVisitor;
@@ -105,32 +102,7 @@ public class MaterializeTLPAggregateOracle extends MaterializeTLPBase implements
     }
 
     private String getAggregateResult(String queryString) throws SQLException {
-        // log TLP Aggregate SELECT queries on the current log file
-        if (state.getOptions().logEachSelect()) {
-            // TODO: refactor me
-            state.getLogger().writeCurrent(queryString);
-            try {
-                state.getLogger().getCurrentFileWriter().flush();
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-        }
-        String resultString;
-        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
-        try (SQLancerResultSet result = q.executeAndGet(state)) {
-            if (result == null) {
-                throw new IgnoreMeException();
-            }
-            if (!result.next()) {
-                resultString = null;
-            } else {
-                resultString = result.getString(1);
-            }
-        } catch (PSQLException e) {
-            throw new AssertionError(queryString, e);
-        }
-        return resultString;
+        return executeQuery(state, queryString, errors);
     }
 
     private List<MaterializeExpression> mapped(MaterializeAggregate aggregate) {

--- a/src/sqlancer/postgres/PostgresUtils.java
+++ b/src/sqlancer/postgres/PostgresUtils.java
@@ -1,0 +1,52 @@
+package sqlancer.postgres;
+
+import static sqlancer.postgres.ast.PostgresConstant.createIntConstant;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.postgres.PostgresSchema.PostgresDataType;
+import sqlancer.postgres.PostgresSchema.PostgresTables;
+import sqlancer.postgres.ast.PostgresExpression;
+import sqlancer.postgres.ast.PostgresSelect;
+import sqlancer.postgres.ast.PostgresSelect.ForClause;
+import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
+import sqlancer.postgres.gen.PostgresExpressionGenerator;
+
+public final class PostgresUtils {
+
+    private PostgresUtils() {
+    }
+
+    public static PostgresSubquery createSubquery(PostgresGlobalState globalState, String name, PostgresTables tables) {
+        List<PostgresExpression> columns = new ArrayList<>();
+        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState).setColumns(tables.getColumns());
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            columns.add(gen.generateExpression(0));
+        }
+        PostgresSelect select = new PostgresSelect();
+        select.setFromList(tables.getTables().stream().map(t -> new PostgresFromTable(t, Randomly.getBoolean()))
+                .collect(Collectors.toList()));
+        select.setFetchColumns(columns);
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression(0, PostgresDataType.BOOLEAN));
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByClauses(gen.generateOrderBys());
+        }
+        if (Randomly.getBoolean()) {
+            select.setLimitClause(createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
+            if (Randomly.getBoolean()) {
+                select.setOffsetClause(createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
+            }
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setForClause(ForClause.getRandom());
+        }
+        return new PostgresSubquery(select, name);
+    }
+
+}

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -1,5 +1,7 @@
 package sqlancer.postgres.gen;
 
+import static sqlancer.postgres.PostgresUtils.createSubquery;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,7 +64,6 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresPrefixOperation.PrefixOperator;
 import sqlancer.postgres.ast.PostgresSelect;
-import sqlancer.postgres.ast.PostgresSelect.ForClause;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.ast.PostgresSimilarTo;
@@ -607,35 +608,6 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
     public PostgresExpressionGenerator allowAggregates(boolean value) {
         allowAggregateFunctions = value;
         return this;
-    }
-
-    public static PostgresSubquery createSubquery(PostgresGlobalState globalState, String name, PostgresTables tables) {
-        List<PostgresExpression> columns = new ArrayList<>();
-        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState).setColumns(tables.getColumns());
-        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
-            columns.add(gen.generateExpression(0));
-        }
-        PostgresSelect select = new PostgresSelect();
-        select.setFromList(tables.getTables().stream().map(t -> new PostgresFromTable(t, Randomly.getBoolean()))
-                .collect(Collectors.toList()));
-        select.setFetchColumns(columns);
-        if (Randomly.getBoolean()) {
-            select.setWhereClause(gen.generateExpression(0, PostgresDataType.BOOLEAN));
-        }
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            select.setOrderByClauses(gen.generateOrderBys());
-        }
-        if (Randomly.getBoolean()) {
-            select.setLimitClause(PostgresConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
-            if (Randomly.getBoolean()) {
-                select.setOffsetClause(
-                        PostgresConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
-            }
-        }
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            select.setForClause(ForClause.getRandom());
-        }
-        return new PostgresSubquery(select, name);
     }
 
     @Override

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -126,18 +126,9 @@ public class PostgresPivotedQuerySynthesisOracle
         sb.append(") as result WHERE ");
         int i = 0;
         for (PostgresColumn c : fetchColumns) {
-            if (i++ != 0) {
-                sb.append(" AND ");
-            }
-            sb.append("result.");
-            sb.append(c.getTable().getName());
-            sb.append(c.getName());
-            if (pivotRow.getValues().get(c).isNull()) {
-                sb.append(" IS NULL");
-            } else {
-                sb.append(" = ");
-                sb.append(pivotRow.getValues().get(c).getTextRepresentation());
-            }
+            sb = appendColumn(sb, pivotRow.getValues().get(c).isNull(),
+                    pivotRow.getValues().get(c).getTextRepresentation(), i, c);
+            i++;
         }
         String resultingQueryString = sb.toString();
         return new SQLQueryAdapter(resultingQueryString, errors);

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -1,20 +1,17 @@
 package sqlancer.postgres.oracle.tlp;
 
-import java.io.IOException;
+import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.postgresql.util.PSQLException;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresVisitor;
@@ -102,32 +99,7 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
     }
 
     private String getAggregateResult(String queryString) throws SQLException {
-        // log TLP Aggregate SELECT queries on the current log file
-        if (state.getOptions().logEachSelect()) {
-            // TODO: refactor me
-            state.getLogger().writeCurrent(queryString);
-            try {
-                state.getLogger().getCurrentFileWriter().flush();
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-        }
-        String resultString;
-        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
-        try (SQLancerResultSet result = q.executeAndGet(state)) {
-            if (result == null) {
-                throw new IgnoreMeException();
-            }
-            if (!result.next()) {
-                resultString = null;
-            } else {
-                resultString = result.getString(1);
-            }
-        } catch (PSQLException e) {
-            throw new AssertionError(queryString, e);
-        }
-        return resultString;
+        return executeQuery(state, queryString, errors);
     }
 
     private List<PostgresExpression> mapped(PostgresAggregate aggregate) {

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -1,5 +1,6 @@
 package sqlancer.postgres.oracle.tlp;
 
+import static sqlancer.common.oracle.TestOracleUtils.executeAndCompareQueries;
 import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
 
 import java.sql.SQLException;
@@ -7,8 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.oracle.TestOracle;
@@ -65,20 +64,7 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
         secondResult = getAggregateResult(metamorphicQuery);
 
-        String queryFormatString = "-- %s;\n-- result: %s";
-        String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
-        String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
-        state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
-        if (firstResult == null && secondResult != null || firstResult != null && secondResult == null
-                || firstResult != null && !firstResult.contentEquals(secondResult)
-                        && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
-            if (secondResult != null && secondResult.contains("Inf")) {
-                throw new IgnoreMeException(); // FIXME: average computation
-            }
-            String assertionMessage = String.format("the results mismatch!\n%s\n%s", firstQueryString,
-                    secondQueryString);
-            throw new AssertionError(assertionMessage);
-        }
+        executeAndCompareQueries(state, originalQuery, firstResult, metamorphicQuery, secondResult);
     }
 
     private String createMetamorphicUnionQuery(PostgresSelect select, PostgresAggregate aggregate,

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.postgres.oracle.tlp;
 
 import static sqlancer.common.oracle.TestOracleUtils.executeAndCompareQueries;
-import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -27,8 +26,6 @@ import sqlancer.postgres.gen.PostgresCommon;
 
 public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestOracle<PostgresGlobalState> {
 
-    private String firstResult;
-    private String secondResult;
     private String originalQuery;
     private String metamorphicQuery;
 
@@ -60,11 +57,8 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
             select.setOrderByClauses(gen.generateOrderBys());
         }
         originalQuery = PostgresVisitor.asString(select);
-        firstResult = getAggregateResult(originalQuery);
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
-        secondResult = getAggregateResult(metamorphicQuery);
-
-        executeAndCompareQueries(state, originalQuery, firstResult, metamorphicQuery, secondResult);
+        executeAndCompareQueries(state, originalQuery, metamorphicQuery, errors);
     }
 
     private String createMetamorphicUnionQuery(PostgresSelect select, PostgresAggregate aggregate,
@@ -82,10 +76,6 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
                 + PostgresVisitor.asString(middleSelect) + " UNION ALL " + PostgresVisitor.asString(rightSelect);
         metamorphicQuery += ") as asdf";
         return metamorphicQuery;
-    }
-
-    private String getAggregateResult(String queryString) throws SQLException {
-        return executeQuery(state, queryString, errors);
     }
 
     private List<PostgresExpression> mapped(PostgresAggregate aggregate) {

--- a/src/sqlancer/yugabyte/ysql/YSQLUtils.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLUtils.java
@@ -1,0 +1,48 @@
+package sqlancer.yugabyte.ysql;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.JoinBase.JoinType;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+
+/**
+ * Utility class for YSQL-related operations.
+ */
+public final class YSQLUtils {
+
+    private YSQLUtils() {
+    }
+
+    public static List<YSQLJoin> getJoinStatements(YSQLGlobalState globalState, List<YSQLSchema.YSQLColumn> columns,
+            List<YSQLTable> tables) {
+        List<YSQLJoin> joinStatements = new ArrayList<>();
+        YSQLExpressionGenerator gen = new YSQLExpressionGenerator(globalState).setColumns(columns);
+        for (int i = 1; i < tables.size(); i++) {
+            YSQLExpression joinClause = gen.generateExpression(YSQLDataType.BOOLEAN);
+            YSQLTable table = Randomly.fromList(tables);
+            tables.remove(table);
+            JoinType options = JoinType.getRandomForDatabase("YSQL");
+            YSQLJoin j = new YSQLJoin(new YSQLSelect.YSQLFromTable(table, Randomly.getBoolean()), joinClause, options);
+            joinStatements.add(j);
+        }
+        // JOIN subqueries
+        for (int i = 0; i < Randomly.smallNumber(); i++) {
+            YSQLTables subqueryTables = globalState.getSchema().getRandomTableNonEmptyTables();
+            YSQLSelect.YSQLSubquery subquery = YSQLExpressionGenerator.createSubquery(globalState,
+                    String.format("sub%d", i), subqueryTables);
+            YSQLExpression joinClause = gen.generateExpression(YSQLDataType.BOOLEAN);
+            JoinType options = JoinType.getRandomForDatabase("YSQL");
+            YSQLJoin j = new YSQLJoin(subquery, joinClause, options);
+            joinStatements.add(j);
+        }
+        return joinStatements;
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLUtils.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLUtils.java
@@ -5,12 +5,12 @@ import java.util.List;
 
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase.JoinType;
-import sqlancer.yugabyte.ysql.ast.YSQLExpression;
-import sqlancer.yugabyte.ysql.ast.YSQLJoin;
-import sqlancer.yugabyte.ysql.ast.YSQLSelect;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
 import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
 
 /**

--- a/src/sqlancer/yugabyte/ysql/YSQLUtils.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLUtils.java
@@ -8,10 +8,10 @@ import sqlancer.common.ast.JoinBase.JoinType;
 import sqlancer.yugabyte.ysql.ast.YSQLExpression;
 import sqlancer.yugabyte.ysql.ast.YSQLJoin;
 import sqlancer.yugabyte.ysql.ast.YSQLSelect;
-import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
 
 /**
  * Utility class for YSQL-related operations.

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLExpressionGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLExpressionGenerator.java
@@ -1,5 +1,7 @@
 package sqlancer.yugabyte.ysql.gen;
 
+import static sqlancer.yugabyte.ysql.YSQLUtils.getJoinStatements;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,7 +12,6 @@ import java.util.stream.Stream;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
-import sqlancer.common.ast.JoinBase.JoinType;
 import sqlancer.common.gen.ExpressionGenerator;
 import sqlancer.common.gen.NoRECGenerator;
 import sqlancer.common.gen.TLPWhereGenerator;
@@ -622,26 +623,7 @@ public class YSQLExpressionGenerator implements ExpressionGenerator<YSQLExpressi
 
     @Override
     public List<YSQLJoin> getRandomJoinClauses() {
-        List<YSQLJoin> joinStatements = new ArrayList<>();
-        YSQLExpressionGenerator gen = new YSQLExpressionGenerator(globalState).setColumns(columns);
-        for (int i = 1; i < tables.size(); i++) {
-            YSQLExpression joinClause = gen.generateExpression(YSQLDataType.BOOLEAN);
-            YSQLTable table = Randomly.fromList(tables);
-            tables.remove(table);
-            JoinType options = JoinType.getRandomForDatabase("YSQL");
-            YSQLJoin j = new YSQLJoin(new YSQLSelect.YSQLFromTable(table, Randomly.getBoolean()), joinClause, options);
-            joinStatements.add(j);
-        }
-        // JOIN subqueries
-        for (int i = 0; i < Randomly.smallNumber(); i++) {
-            YSQLTables subqueryTables = globalState.getSchema().getRandomTableNonEmptyTables();
-            YSQLSelect.YSQLSubquery subquery = createSubquery(globalState, String.format("sub%d", i), subqueryTables);
-            YSQLExpression joinClause = gen.generateExpression(YSQLDataType.BOOLEAN);
-            JoinType options = JoinType.getRandomForDatabase("YSQL");
-            YSQLJoin j = new YSQLJoin(subquery, joinClause, options);
-            joinStatements.add(j);
-        }
-        return joinStatements;
+        return getJoinStatements(globalState, columns, tables);
     }
 
     @Override

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLPivotedQuerySynthesisOracle.java
@@ -92,18 +92,9 @@ public class YSQLPivotedQuerySynthesisOracle
         sb.append(") as result WHERE ");
         int i = 0;
         for (YSQLColumn c : fetchColumns) {
-            if (i++ != 0) {
-                sb.append(" AND ");
-            }
-            sb.append("result.");
-            sb.append(c.getTable().getName());
-            sb.append(c.getName());
-            if (pivotRow.getValues().get(c).isNull()) {
-                sb.append(" IS NULL");
-            } else {
-                sb.append(" = ");
-                sb.append(pivotRow.getValues().get(c).getTextRepresentation());
-            }
+            sb = appendColumn(sb, pivotRow.getValues().get(c).isNull(),
+                    pivotRow.getValues().get(c).getTextRepresentation(), i, c);
+            i++;
         }
         String resultingQueryString = sb.toString();
         return new SQLQueryAdapter(resultingQueryString, errors);

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
@@ -1,20 +1,17 @@
 package sqlancer.yugabyte.ysql.oracle.tlp;
 
-import java.io.IOException;
+import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.postgresql.util.PSQLException;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.yugabyte.ysql.YSQLErrors;
 import sqlancer.yugabyte.ysql.YSQLGlobalState;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
@@ -101,32 +98,7 @@ public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle<YS
     }
 
     private String getAggregateResult(String queryString) throws SQLException {
-        // log TLP Aggregate SELECT queries on the current log file
-        if (state.getOptions().logEachSelect()) {
-            // TODO: refactor me
-            state.getLogger().writeCurrent(queryString);
-            try {
-                state.getLogger().getCurrentFileWriter().flush();
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-        }
-        String resultString;
-        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
-        try (SQLancerResultSet result = q.executeAndGet(state)) {
-            if (result == null) {
-                throw new IgnoreMeException();
-            }
-            if (!result.next()) {
-                resultString = null;
-            } else {
-                resultString = result.getString(1);
-            }
-        } catch (PSQLException e) {
-            throw new AssertionError(queryString, e);
-        }
-        return resultString;
+        return executeQuery(state, queryString, errors);
     }
 
     private List<YSQLExpression> mapped(YSQLAggregate aggregate) {

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.yugabyte.ysql.oracle.tlp;
 
 import static sqlancer.common.oracle.TestOracleUtils.executeAndCompareQueries;
-import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -27,8 +26,6 @@ import sqlancer.yugabyte.ysql.ast.YSQLSelect;
 
 public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle<YSQLGlobalState> {
 
-    private String firstResult;
-    private String secondResult;
     private String originalQuery;
     private String metamorphicQuery;
 
@@ -60,10 +57,8 @@ public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle<YS
             select.setOrderByClauses(gen.generateOrderBys());
         }
         originalQuery = YSQLVisitor.asString(select);
-        firstResult = getAggregateResult(originalQuery);
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
-        secondResult = getAggregateResult(metamorphicQuery);
-        executeAndCompareQueries(state, originalQuery, firstResult, metamorphicQuery, secondResult);
+        executeAndCompareQueries(state, originalQuery, metamorphicQuery, errors);
 
     }
 
@@ -81,10 +76,6 @@ public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle<YS
                 + " UNION ALL " + YSQLVisitor.asString(rightSelect);
         metamorphicQuery += ") as asdf";
         return metamorphicQuery;
-    }
-
-    private String getAggregateResult(String queryString) throws SQLException {
-        return executeQuery(state, queryString, errors);
     }
 
     private List<YSQLExpression> mapped(YSQLAggregate aggregate) {

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
@@ -1,5 +1,6 @@
 package sqlancer.yugabyte.ysql.oracle.tlp;
 
+import static sqlancer.common.oracle.TestOracleUtils.executeAndCompareQueries;
 import static sqlancer.common.oracle.TestOracleUtils.executeQuery;
 
 import java.sql.SQLException;
@@ -7,8 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.ast.JoinBase;
 import sqlancer.common.oracle.TestOracle;
@@ -64,21 +63,8 @@ public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle<YS
         firstResult = getAggregateResult(originalQuery);
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
         secondResult = getAggregateResult(metamorphicQuery);
+        executeAndCompareQueries(state, originalQuery, firstResult, metamorphicQuery, secondResult);
 
-        String queryFormatString = "-- %s;\n-- result: %s";
-        String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
-        String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
-        state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
-        if (firstResult == null && secondResult != null || firstResult != null && secondResult == null
-                || firstResult != null && !firstResult.contentEquals(secondResult)
-                        && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
-            if (secondResult != null && secondResult.contains("Inf")) {
-                throw new IgnoreMeException(); // FIXME: average computation
-            }
-            String assertionMessage = String.format("the results mismatch!\n%s\n%s", firstQueryString,
-                    secondQueryString);
-            throw new AssertionError(assertionMessage);
-        }
     }
 
     private String createMetamorphicUnionQuery(YSQLSelect select, YSQLAggregate aggregate, List<YSQLExpression> from) {


### PR DESCRIPTION
In this PR:

1. Created utility classes (`CockroachDbUtils`, `YSQLUtils`, `MaterializeUtils`, `PostgresUtils`) to centralize common logic used across different components of the same database.
2. Moved shared functionality to base classes, including `appendColumn` into `PivotedQuerySynthesisBase` and `getQueryStrings` into `DorisQueryPartitioningBase`.
3. Consolidated testing logic by extracting functions like `executeAndCompareQueries` and `getAggregateResult` into `TestOracleUtils`, making them available across different database implementations.