### PR TITLE
Refactor ExpressionGenerator classes

### DIFF
--- a/src/sqlancer/SQLPair.java
+++ b/src/sqlancer/SQLPair.java
@@ -1,10 +1,10 @@
-package sqlancer.presto;
+package sqlancer;
 
-public class PrestoPair<T, U> {
+public class SQLPair<T, U> {
     private final T first;
     private final U second;
 
-    public PrestoPair(T first, U second) {
+    public SQLPair(T first, U second) {
         this.first = first;
         this.second = second;
     }

--- a/src/sqlancer/clickhouse/gen/ClickHouseExpressionGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseExpressionGenerator.java
@@ -103,33 +103,7 @@ public class ClickHouseExpressionGenerator
             return new ClickHouseAggregate(generateExpressionWithColumns(columns, remainingDepth - 1),
                     ClickHouseAggregate.ClickHouseAggregateFunction.getRandom());
         }
-        if (columns.isEmpty() || remainingDepth <= 2 && Randomly.getBooleanWithRatherLowProbability()) {
-            return generateConstant(null);
-        }
-
-        if (remainingDepth <= 2 || Randomly.getBooleanWithRatherLowProbability()) {
-            return columns.get((int) Randomly.getNotCachedInteger(0, columns.size() - 1));
-        }
-
-        ColumnLike expr = Randomly.fromOptions(ColumnLike.values());
-        switch (expr) {
-        case UNARY_PREFIX:
-            return new ClickHouseUnaryPrefixOperation(generateExpressionWithColumns(columns, remainingDepth - 1),
-                    ClickHouseUnaryPrefixOperator.MINUS);
-        case BINARY_ARITHMETIC:
-            return new ClickHouseBinaryArithmeticOperation(generateExpressionWithColumns(columns, remainingDepth - 1),
-                    generateExpressionWithColumns(columns, remainingDepth - 1),
-                    ClickHouseBinaryArithmeticOperation.ClickHouseBinaryArithmeticOperator.getRandom());
-        case UNARY_FUNCTION:
-            return new ClickHouseUnaryFunctionOperation(generateExpressionWithColumns(columns, remainingDepth - 1),
-                    ClickHouseUnaryFunctionOperation.ClickHouseUnaryFunctionOperator.getRandom());
-        case BINARY_FUNCTION:
-            return new ClickHouseBinaryFunctionOperation(generateExpressionWithColumns(columns, remainingDepth - 1),
-                    generateExpressionWithColumns(columns, remainingDepth - 1),
-                    ClickHouseBinaryFunctionOperation.ClickHouseBinaryFunctionOperator.getRandom());
-        default:
-            throw new AssertionError(expr);
-        }
+        return generateExpressionWithColumns(columns, remainingDepth);
     }
 
     public ClickHouseExpression generateExpressionWithExpression(List<ClickHouseExpression> expression,
@@ -274,20 +248,24 @@ public class ClickHouseExpressionGenerator
         List<ClickHouseTableReference> leftTables = new ArrayList<>();
         leftTables.add(left);
         if (Randomly.getBoolean() && !tables.isEmpty()) {
-            int nrJoinClauses = (int) Randomly.getNotCachedInteger(0, tables.size());
-            for (int i = 0; i < nrJoinClauses; i++) {
-                ClickHouseTableReference leftTable = leftTables
-                        .get((int) Randomly.getNotCachedInteger(0, leftTables.size() - 1));
-                ClickHouseTableReference rightTable = new ClickHouseTableReference(Randomly.fromList(tables),
-                        "right_" + i);
-                ClickHouseJoinOnClause joinClause = generateJoinClause(leftTable, rightTable);
-                ClickHouseJoin.JoinType options = Randomly.fromOptions(ClickHouseJoin.JoinType.getValues("CLICKHOUSE"));
-                ClickHouseJoin j = new ClickHouseJoin(leftTable, rightTable, options, joinClause);
-                joinStatements.add(j);
-                leftTables.add(rightTable);
-            }
+            generateRandomJoins(tables, joinStatements, leftTables);
         }
         return joinStatements;
+    }
+
+    private void generateRandomJoins(List<ClickHouseTable> tables, List<ClickHouseJoin> joinStatements,
+            List<ClickHouseTableReference> leftTables) {
+        int nrJoinClauses = (int) Randomly.getNotCachedInteger(0, tables.size());
+        for (int i = 0; i < nrJoinClauses; i++) {
+            ClickHouseTableReference leftTable = leftTables
+                    .get((int) Randomly.getNotCachedInteger(0, leftTables.size() - 1));
+            ClickHouseTableReference rightTable = new ClickHouseTableReference(Randomly.fromList(tables), "right_" + i);
+            ClickHouseJoinOnClause joinClause = generateJoinClause(leftTable, rightTable);
+            ClickHouseJoin.JoinType options = Randomly.fromOptions(ClickHouseJoin.JoinType.getValues("CLICKHOUSE"));
+            ClickHouseJoin j = new ClickHouseJoin(leftTable, rightTable, options, joinClause);
+            joinStatements.add(j);
+            leftTables.add(rightTable);
+        }
     }
 
     @Override
@@ -385,18 +363,7 @@ public class ClickHouseExpressionGenerator
         List<ClickHouseTableReference> leftTables = new ArrayList<>();
         leftTables.add(new ClickHouseTableReference(tables.get(0), null));
         if (Randomly.getBoolean() && !tables.isEmpty()) {
-            int nrJoinClauses = (int) Randomly.getNotCachedInteger(0, tables.size());
-            for (int i = 0; i < nrJoinClauses; i++) {
-                ClickHouseTableReference leftTable = leftTables
-                        .get((int) Randomly.getNotCachedInteger(0, leftTables.size() - 1));
-                ClickHouseTableReference rightTable = new ClickHouseTableReference(Randomly.fromList(tables),
-                        "right_" + i);
-                ClickHouseJoinOnClause joinClause = generateJoinClause(leftTable, rightTable);
-                ClickHouseJoin.JoinType options = Randomly.fromOptions(ClickHouseJoin.JoinType.getValues("CLICKHOUSE"));
-                ClickHouseJoin j = new ClickHouseJoin(leftTable, rightTable, options, joinClause);
-                joinStatements.add(j);
-                leftTables.add(rightTable);
-            }
+            generateRandomJoins(tables, joinStatements, leftTables);
         }
         return joinStatements;
     }

--- a/src/sqlancer/clickhouse/gen/ClickHouseExpressionGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseExpressionGenerator.java
@@ -255,8 +255,8 @@ public class ClickHouseExpressionGenerator
 
     private void generateRandomJoins(List<ClickHouseTable> tables, List<ClickHouseJoin> joinStatements,
             List<ClickHouseTableReference> leftTables) {
-        int nrJoinClauses = (int) Randomly.getNotCachedInteger(0, tables.size());
-        for (int i = 0; i < nrJoinClauses; i++) {
+        int numberOfJoinClauses = (int) Randomly.getNotCachedInteger(0, tables.size());
+        for (int i = 0; i < numberOfJoinClauses; i++) {
             ClickHouseTableReference leftTable = leftTables
                     .get((int) Randomly.getNotCachedInteger(0, leftTables.size() - 1));
             ClickHouseTableReference rightTable = new ClickHouseTableReference(Randomly.fromList(tables), "right_" + i);

--- a/src/sqlancer/cnosdb/gen/CnosDBExpressionGenerator.java
+++ b/src/sqlancer/cnosdb/gen/CnosDBExpressionGenerator.java
@@ -208,23 +208,7 @@ public class CnosDBExpressionGenerator implements ExpressionGenerator<CnosDBExpr
 
         if (Randomly.getBooleanWithRatherLowProbability() || depth > maxDepth) {
             // generic expression
-            if (Randomly.getBoolean() || depth > maxDepth) {
-                if (Randomly.getBooleanWithRatherLowProbability()) {
-                    return generateConstant(r, dataType);
-                } else {
-                    if (filterColumns(dataType).isEmpty()) {
-                        return generateConstant(r, dataType);
-                    } else {
-                        return createColumnOfType(dataType);
-                    }
-                }
-            } else {
-                if (Randomly.getBoolean()) {
-                    return generateCastExpression(depth + 1, dataType);
-                } else {
-                    return generateFunctionWithUnknownResult(depth, dataType);
-                }
-            }
+            return generateGenericExpression(depth, dataType);
         } else {
             switch (dataType) {
             case BOOLEAN:
@@ -241,6 +225,30 @@ public class CnosDBExpressionGenerator implements ExpressionGenerator<CnosDBExpr
                 return generateTimeStampExpression(depth);
             default:
                 throw new AssertionError(dataType);
+            }
+        }
+    }
+
+    private CnosDBExpression generateGenericExpression(int depth, CnosDBDataType dataType) {
+        if (Randomly.getBoolean() || depth > maxDepth) {
+            return generateGenericConstant(dataType);
+        } else {
+            if (Randomly.getBoolean()) {
+                return generateCastExpression(depth + 1, dataType);
+            } else {
+                return generateFunctionWithUnknownResult(depth, dataType);
+            }
+        }
+    }
+
+    private CnosDBExpression generateGenericConstant(CnosDBDataType dataType) {
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            return generateConstant(r, dataType);
+        } else {
+            if (filterColumns(dataType).isEmpty()) {
+                return generateConstant(r, dataType);
+            } else {
+                return createColumnOfType(dataType);
             }
         }
     }

--- a/src/sqlancer/common/gen/UntypedExpressionGenerator.java
+++ b/src/sqlancer/common/gen/UntypedExpressionGenerator.java
@@ -6,7 +6,6 @@ import java.util.List;
 import sqlancer.Randomly;
 import sqlancer.common.ast.SelectBase;
 import sqlancer.common.ast.newast.Expression;
-import sqlancer.common.ast.newast.Select;
 
 public abstract class UntypedExpressionGenerator<E extends Expression<?>, C> implements ExpressionGenerator<E> {
 

--- a/src/sqlancer/common/gen/UntypedExpressionGenerator.java
+++ b/src/sqlancer/common/gen/UntypedExpressionGenerator.java
@@ -4,8 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Select;
 
-public abstract class UntypedExpressionGenerator<E, C> implements ExpressionGenerator<E> {
+public abstract class UntypedExpressionGenerator<E extends Expression<?>, C> implements ExpressionGenerator<E> {
 
     protected List<C> columns;
     protected boolean allowAggregates;
@@ -68,4 +71,19 @@ public abstract class UntypedExpressionGenerator<E, C> implements ExpressionGene
         return generateExpression();
     }
 
+    public <S extends SelectBase<E>> boolean mutateHaving(S select) {
+        if (select.getGroupByExpressions().size() == 0) {
+            select.setGroupByExpressions(select.getFetchColumns());
+            select.setHavingClause(generateHavingClause());
+            return false;
+        } else {
+            if (select.getHavingClause() == null) {
+                select.setHavingClause(generateHavingClause());
+                return false;
+            } else {
+                select.setHavingClause(null);
+                return true;
+            }
+        }
+    }
 }

--- a/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
@@ -299,10 +299,6 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
             this.isVariadic = isVariadic;
         }
 
-        public static DBFunction getRandom() {
-            return Randomly.fromOptions(values());
-        }
-
         public int getNrArgs() {
             if (isVariadic) {
                 return Randomly.smallNumber() + nrArgs;
@@ -311,6 +307,9 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
             }
         }
 
+        public static DBFunction getRandom() {
+            return Randomly.fromOptions(values());
+        }
     }
 
     public enum DuckDBUnaryPostfixOperator implements Operator {

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -310,22 +310,6 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
         return increase;
     }
 
-    boolean mutateHaving(MySQLSelect select) {
-        if (select.getGroupByExpressions().size() == 0) {
-            select.setGroupByExpressions(select.getFetchColumns());
-            select.setHavingClause(generateExpression());
-            return false;
-        } else {
-            if (select.getHavingClause() == null) {
-                select.setHavingClause(generateExpression());
-                return false;
-            } else {
-                select.setHavingClause(null);
-                return true;
-            }
-        }
-    }
-
     boolean mutateAnd(MySQLSelect select) {
         if (select.getWhereClause() == null) {
             select.setWhereClause(generateExpression());

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -678,7 +678,7 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
     @Override
     public List<PostgresExpression> generateFetchColumns(boolean shouldCreateDummy) {
         if (shouldCreateDummy && Randomly.getBooleanWithRatherLowProbability()) {
-            return List.of(new PostgresColumnValue(PostgresColumn.createDummy("*"), null));
+            return Arrays.asList(new PostgresColumnValue(PostgresColumn.createDummy("*"), null));
         }
         allowAggregateFunctions = true;
         List<PostgresExpression> fetchColumns = new ArrayList<>();
@@ -696,9 +696,9 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         PostgresColumnValue allColumns = new PostgresColumnValue(PostgresColumn.createDummy("*"), null);
         if (shouldUseAggregate) {
             select.setFetchColumns(
-                    List.of(new PostgresAggregate(List.of(allColumns), PostgresAggregateFunction.COUNT)));
+                    Arrays.asList(new PostgresAggregate(List.of(allColumns), PostgresAggregateFunction.COUNT)));
         } else {
-            select.setFetchColumns(List.of(allColumns));
+            select.setFetchColumns(Arrays.asList(allColumns));
         }
         select.setWhereClause(whereCondition);
         if (Randomly.getBooleanWithSmallProbability()) {
@@ -713,7 +713,7 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         PostgresCastOperation isTrue = new PostgresCastOperation(whereCondition,
                 PostgresCompoundDataType.create(PostgresDataType.INT));
         PostgresPostfixText asText = new PostgresPostfixText(isTrue, " as count", null, PostgresDataType.INT);
-        select.setFetchColumns(List.of(asText));
+        select.setFetchColumns(Arrays.asList(asText));
         select.setWhereClause(null);
         select.setOrderByClauses(List.of());
         select.setSelectType(SelectType.ALL);

--- a/src/sqlancer/presto/PrestoPair.java
+++ b/src/sqlancer/presto/PrestoPair.java
@@ -1,0 +1,24 @@
+package sqlancer.presto;
+
+public class PrestoPair<T, U> {
+    private final T first;
+    private final U second;
+
+    public PrestoPair(T first, U second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    public T getFirstValue() {
+        return first;
+    }
+
+    public U getSecondValue() {
+        return second;
+    }
+
+    @Override
+    public String toString() {
+        return "Pair[" + first + ", " + second + "]";
+    }
+}

--- a/src/sqlancer/presto/PrestoUtils.java
+++ b/src/sqlancer/presto/PrestoUtils.java
@@ -1,0 +1,39 @@
+package sqlancer.presto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public final class PrestoUtils {
+    private PrestoUtils() {
+    }
+
+    public static PrestoPair<List<PrestoExpression>, PrestoSchema.PrestoCompositeDataType> generateVariadicArguments(
+            PrestoTypedExpressionGenerator generator, PrestoSchema.PrestoDataType dataType,
+            PrestoSchema.PrestoCompositeDataType savedArrayType, int depth) {
+
+        List<PrestoExpression> arguments = new ArrayList<>();
+        PrestoSchema.PrestoCompositeDataType currentArrayType = savedArrayType;
+        // TODO: consider upper
+        long no = Randomly.getNotCachedInteger(2, 10);
+
+        for (int i = 0; i < no; i++) {
+            PrestoSchema.PrestoCompositeDataType type;
+
+            if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
+                if (currentArrayType == null) {
+                    currentArrayType = dataType.get();
+                }
+                type = currentArrayType;
+            } else {
+                type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
+            }
+            arguments.add(generator.generateExpression(type, depth + 1));
+        }
+
+        return new PrestoPair<>(arguments, currentArrayType);
+    }
+}

--- a/src/sqlancer/presto/PrestoUtils.java
+++ b/src/sqlancer/presto/PrestoUtils.java
@@ -4,18 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
-import sqlancer.presto.ast.PrestoExpression;
-import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
 
 public final class PrestoUtils {
+
     private PrestoUtils() {
     }
 
-    public static PrestoPair<List<PrestoExpression>, PrestoSchema.PrestoCompositeDataType> generateVariadicArguments(
-            PrestoTypedExpressionGenerator generator, PrestoSchema.PrestoDataType dataType,
-            PrestoSchema.PrestoCompositeDataType savedArrayType, int depth) {
+    public static PrestoPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> prepareVariadicArgumentTypes(
+            PrestoSchema.PrestoDataType dataType, PrestoSchema.PrestoCompositeDataType savedArrayType) {
 
-        List<PrestoExpression> arguments = new ArrayList<>();
+        List<PrestoSchema.PrestoCompositeDataType> typeList = new ArrayList<>();
         PrestoSchema.PrestoCompositeDataType currentArrayType = savedArrayType;
         // TODO: consider upper
         long no = Randomly.getNotCachedInteger(2, 10);
@@ -31,9 +29,9 @@ public final class PrestoUtils {
             } else {
                 type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
             }
-            arguments.add(generator.generateExpression(type, depth + 1));
+            typeList.add(type);
         }
 
-        return new PrestoPair<>(arguments, currentArrayType);
+        return new PrestoPair<>(typeList, currentArrayType);
     }
 }

--- a/src/sqlancer/presto/PrestoUtils.java
+++ b/src/sqlancer/presto/PrestoUtils.java
@@ -4,13 +4,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.SQLPair;
 
 public final class PrestoUtils {
 
     private PrestoUtils() {
     }
 
-    public static PrestoPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> prepareVariadicArgumentTypes(
+    public static SQLPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> prepareVariadicArgumentTypes(
             PrestoSchema.PrestoDataType dataType, PrestoSchema.PrestoCompositeDataType savedArrayType) {
 
         List<PrestoSchema.PrestoCompositeDataType> typeList = new ArrayList<>();
@@ -32,6 +33,6 @@ public final class PrestoUtils {
             typeList.add(type);
         }
 
-        return new PrestoPair<>(typeList, currentArrayType);
+        return new SQLPair<>(typeList, currentArrayType);
     }
 }

--- a/src/sqlancer/presto/ast/PrestoFunction.java
+++ b/src/sqlancer/presto/ast/PrestoFunction.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
-import sqlancer.presto.PrestoPair;
+import sqlancer.SQLPair;
 import sqlancer.presto.PrestoSchema;
 import sqlancer.presto.PrestoUtils;
 import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
@@ -30,7 +30,7 @@ public interface PrestoFunction extends PrestoExpression {
         }
         // -1 - unlimited number of arguments
         if (getNumberOfArguments() == -1) {
-            PrestoPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> result = PrestoUtils
+            SQLPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> result = PrestoUtils
                     .prepareVariadicArgumentTypes(argumentTypes[0], savedArrayType);
 
             List<PrestoSchema.PrestoCompositeDataType> typeList = result.getFirstValue();

--- a/src/sqlancer/presto/ast/PrestoFunction.java
+++ b/src/sqlancer/presto/ast/PrestoFunction.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.presto.PrestoPair;
 import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoUtils;
 import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
 
 public interface PrestoFunction extends PrestoExpression {
@@ -28,20 +30,13 @@ public interface PrestoFunction extends PrestoExpression {
         }
         // -1 - unlimited number of arguments
         if (getNumberOfArguments() == -1) {
-            PrestoSchema.PrestoDataType dataType = argumentTypes[0];
-            // TODO: consider upper
-            long no = Randomly.getNotCachedInteger(2, 10);
-            for (int i = 0; i < no; i++) {
-                PrestoSchema.PrestoCompositeDataType type;
+            PrestoPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> result = PrestoUtils
+                    .prepareVariadicArgumentTypes(argumentTypes[0], savedArrayType);
 
-                if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
-                    if (savedArrayType == null) {
-                        savedArrayType = dataType.get();
-                    }
-                    type = savedArrayType;
-                } else {
-                    type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
-                }
+            List<PrestoSchema.PrestoCompositeDataType> typeList = result.getFirstValue();
+            savedArrayType = result.getSecondValue();
+
+            for (PrestoSchema.PrestoCompositeDataType type : typeList) {
                 arguments.add(gen.generateExpression(type, depth + 1));
             }
         } else {

--- a/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
@@ -211,10 +211,16 @@ public final class PrestoTypedExpressionGenerator extends
             savedArrayType = returnType;
         }
         if (function.getNumberOfArguments() == -1) {
-            PrestoPair<List<PrestoExpression>, PrestoCompositeDataType> result = PrestoUtils
-                    .generateVariadicArguments(this, argumentTypes[0], savedArrayType, depth);
-            arguments = result.getFirstValue();
+            PrestoPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> result = PrestoUtils
+                    .prepareVariadicArgumentTypes(argumentTypes[0], savedArrayType);
+
+            List<PrestoSchema.PrestoCompositeDataType> typeList = result.getFirstValue();
             savedArrayType = result.getSecondValue();
+
+            // Generate expressions outside the helper function
+            for (PrestoSchema.PrestoCompositeDataType type : typeList) {
+                arguments.add(generateExpression(type, depth + 1));
+            }
         } else {
             for (PrestoSchema.PrestoDataType arg : argumentTypes) {
                 PrestoSchema.PrestoCompositeDataType dataType;

--- a/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
@@ -15,12 +15,14 @@ import sqlancer.common.gen.TypedExpressionGenerator;
 import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.schema.AbstractTables;
 import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoPair;
 import sqlancer.presto.PrestoSchema;
 import sqlancer.presto.PrestoSchema.PrestoColumn;
 import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
 import sqlancer.presto.PrestoSchema.PrestoDataType;
 import sqlancer.presto.PrestoSchema.PrestoTable;
 import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.PrestoUtils;
 import sqlancer.presto.ast.PrestoAggregateFunction;
 import sqlancer.presto.ast.PrestoAtTimeZoneOperator;
 import sqlancer.presto.ast.PrestoBetweenOperation;
@@ -209,22 +211,10 @@ public final class PrestoTypedExpressionGenerator extends
             savedArrayType = returnType;
         }
         if (function.getNumberOfArguments() == -1) {
-            PrestoSchema.PrestoDataType dataType = argumentTypes[0];
-            // TODO: consider upper
-            long no = Randomly.getNotCachedInteger(2, 10);
-            for (int i = 0; i < no; i++) {
-                PrestoSchema.PrestoCompositeDataType type;
-
-                if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
-                    if (savedArrayType == null) {
-                        savedArrayType = dataType.get();
-                    }
-                    type = savedArrayType;
-                } else {
-                    type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
-                }
-                arguments.add(generateExpression(type, depth + 1));
-            }
+            PrestoPair<List<PrestoExpression>, PrestoCompositeDataType> result = PrestoUtils
+                    .generateVariadicArguments(this, argumentTypes[0], savedArrayType, depth);
+            arguments = result.getFirstValue();
+            savedArrayType = result.getSecondValue();
         } else {
             for (PrestoSchema.PrestoDataType arg : argumentTypes) {
                 PrestoSchema.PrestoCompositeDataType dataType;

--- a/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
+import sqlancer.SQLPair;
 import sqlancer.common.ast.BinaryOperatorNode;
 import sqlancer.common.gen.NoRECGenerator;
 import sqlancer.common.gen.TLPWhereGenerator;
@@ -15,7 +16,6 @@ import sqlancer.common.gen.TypedExpressionGenerator;
 import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.schema.AbstractTables;
 import sqlancer.presto.PrestoGlobalState;
-import sqlancer.presto.PrestoPair;
 import sqlancer.presto.PrestoSchema;
 import sqlancer.presto.PrestoSchema.PrestoColumn;
 import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
@@ -211,7 +211,7 @@ public final class PrestoTypedExpressionGenerator extends
             savedArrayType = returnType;
         }
         if (function.getNumberOfArguments() == -1) {
-            PrestoPair<List<PrestoSchema.PrestoCompositeDataType>, PrestoSchema.PrestoCompositeDataType> result = PrestoUtils
+            SQLPair<List<PrestoCompositeDataType>, PrestoCompositeDataType> result = PrestoUtils
                     .prepareVariadicArgumentTypes(argumentTypes[0], savedArrayType);
 
             List<PrestoSchema.PrestoCompositeDataType> typeList = result.getFirstValue();

--- a/src/sqlancer/tidb/TiDBExpressionGenerator.java
+++ b/src/sqlancer/tidb/TiDBExpressionGenerator.java
@@ -297,22 +297,6 @@ public class TiDBExpressionGenerator extends UntypedExpressionGenerator<TiDBExpr
         return increase;
     }
 
-    boolean mutateHaving(TiDBSelect select) {
-        if (select.getGroupByExpressions().size() == 0) {
-            select.setGroupByExpressions(select.getFetchColumns());
-            select.setHavingClause(generateExpression());
-            return false;
-        } else {
-            if (select.getHavingClause() == null) {
-                select.setHavingClause(generateExpression());
-                return false;
-            } else {
-                select.setHavingClause(null);
-                return true;
-            }
-        }
-    }
-
     boolean mutateAnd(TiDBSelect select) {
         if (select.getWhereClause() == null) {
             select.setWhereClause(generateExpression());

--- a/src/sqlancer/tidb/TiDBExpressionGenerator.java
+++ b/src/sqlancer/tidb/TiDBExpressionGenerator.java
@@ -68,27 +68,7 @@ public class TiDBExpressionGenerator extends UntypedExpressionGenerator<TiDBExpr
     @Override
     public TiDBExpression generateConstant() {
         TiDBDataType type = TiDBDataType.getRandom();
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            return TiDBConstant.createNullConstant();
-        }
-        switch (type) {
-        case INT:
-            return TiDBConstant.createIntConstant(globalState.getRandomly().getInteger());
-        case BLOB:
-        case TEXT:
-            return TiDBConstant.createStringConstant(globalState.getRandomly().getString());
-        case BOOL:
-            return TiDBConstant.createBooleanConstant(Randomly.getBoolean());
-        case FLOATING:
-            return TiDBConstant.createFloatConstant(globalState.getRandomly().getDouble());
-        case CHAR:
-            return TiDBConstant.createStringConstant(globalState.getRandomly().getChar());
-        case DECIMAL:
-        case NUMERIC:
-            return TiDBConstant.createIntConstant(globalState.getRandomly().getInteger());
-        default:
-            throw new AssertionError();
-        }
+        return generateConstant(type);
     }
 
     @Override


### PR DESCRIPTION
1. Reuse `generateExpressionWithColumnsHelper` logic in `ClickhouseExpressionGenerator`
2. Create `generateRandomJoins` helper method to encapsulate join clause generation logic in `ClickhouseExpressionGenerator`
3. Refactor `CnosDBExpressionGenerator`, `PostgresExpressionGenerator` and `MaterializeExpressionGenerator` into smaller methods: `generateGenericExpression` and `generateGenericConstant`.
4. Extract `PrestoTypedExpressionGenerator` and `PrestoFunction` helper methods into `PrestoUtils` to centralize common functionality
6. Reuse `generateConstant(type)` method within `generateConstant()` in `TiDBExpressionGenerator`
7. Extract `mutateHaving` method from database-specific expression generators (`MySQLExpressionGenerator`, `TiDBExpressionGenerator`) into the parent `UntypedExpressionGenerator` class