### PR TITLE
refactor methods in databend doris constant classes

### DIFF
--- a/src/sqlancer/DatabendDorisConstant.java
+++ b/src/sqlancer/DatabendDorisConstant.java
@@ -1,8 +1,6 @@
 package sqlancer;
 
 public class DatabendDorisConstant {
-    public DatabendDorisConstant() {
-    }
 
     public boolean isNull() {
         return false;

--- a/src/sqlancer/DatabendDorisConstant.java
+++ b/src/sqlancer/DatabendDorisConstant.java
@@ -41,5 +41,4 @@ public class DatabendDorisConstant {
         throw new UnsupportedOperationException(this.toString());
     }
 
-
 }

--- a/src/sqlancer/DatabendDorisConstant.java
+++ b/src/sqlancer/DatabendDorisConstant.java
@@ -1,0 +1,45 @@
+package sqlancer;
+
+public class DatabendDorisConstant {
+    public DatabendDorisConstant() {
+    }
+
+    public boolean isNull() {
+        return false;
+    }
+
+    public boolean isInt() {
+        return false;
+    }
+
+    public boolean isBoolean() {
+        return false;
+    }
+
+    public boolean isString() {
+        return false;
+    }
+
+    public boolean isFloat() {
+        return false;
+    }
+
+    public boolean asBoolean() {
+        throw new UnsupportedOperationException(this.toString());
+
+    }
+
+    public long asInt() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public String asString() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public double asFloat() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+
+}

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -97,7 +97,16 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         // }
     }
 
-    public static class DatabendIntConstant extends DatabendConstant {
+    public static abstract class DatabendNumericConstant<T> extends DatabendConstant {
+        protected final T value;
+
+        public DatabendNumericConstant(T value) {
+            this.value = value;
+        }
+
+
+    }
+    public static class DatabendIntConstant extends DatabendNumericConstant<Long> {
 
         private final long value;
 

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -97,21 +97,30 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         // }
     }
 
-    public static abstract class DatabendNumericConstant<T> extends DatabendConstant {
+    public static abstract class DatabendNumericConstant<T extends Number> extends DatabendConstant {
         protected final T value;
 
         public DatabendNumericConstant(T value) {
             this.value = value;
         }
 
-
+        public DatabendConstant isLessThan(DatabendConstant rightVal) {
+            if (rightVal.isNull()) {
+                return DatabendConstant.createNullConstant();
+            } else if (rightVal.isInt()) {
+                return DatabendConstant.createBooleanConstant(value.doubleValue() < rightVal.asInt());
+            } else if (rightVal.isFloat()) {
+                return DatabendConstant.createBooleanConstant(value.doubleValue() < rightVal.asFloat());
+            } else {
+                throw new AssertionError(rightVal);
+            }
+        }
     }
+
     public static class DatabendIntConstant extends DatabendNumericConstant<Long> {
 
-        private final long value;
-
         public DatabendIntConstant(long value) {
-            this.value = value;
+            super(value);
         }
 
         @Override
@@ -162,7 +171,7 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             }
 
         }
-
+/*
         @Override
         public DatabendConstant isLessThan(DatabendConstant rightVal) {
             if (rightVal.isNull()) {
@@ -175,19 +184,18 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
                 throw new AssertionError(rightVal);
             }
         }
-
+*/
         @Override
         public DatabendDataType getExpectedType() {
             return DatabendDataType.INT;
         }
     }
 
-    public static class DatabendFloatConstant extends DatabendConstant {
+    public static class DatabendFloatConstant extends DatabendNumericConstant<Double> {
 
-        private final double value;
 
         public DatabendFloatConstant(double value) {
-            this.value = value;
+            super(value);
         }
 
         public double getValue() {
@@ -216,7 +224,7 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             case FLOAT:
                 return this;
             case INT:
-                return DatabendConstant.createIntConstant((long) value);
+                return DatabendConstant.createIntConstant(value.longValue());
             case BOOLEAN:
                 return DatabendConstant.createBooleanConstant(value != 0);
             case VARCHAR:
@@ -235,7 +243,7 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         public DatabendConstant isEquals(DatabendConstant rightVal) {
             return null;
         }
-
+/*
         @Override
         public DatabendConstant isLessThan(DatabendConstant rightVal) {
             if (rightVal.isNull()) {
@@ -248,6 +256,7 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
                 throw new AssertionError(rightVal);
             }
         }
+ */
     }
 
     public static class DatabendStringConstant extends DatabendConstant {

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -3,13 +3,11 @@ package sqlancer.databend.ast;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
+import sqlancer.DatabendDorisConstant;
 import sqlancer.databend.DatabendSchema.DatabendDataType;
 
-public abstract class DatabendConstant implements DatabendExpression {
-
-    private DatabendConstant() {
-    }
-
+public abstract class DatabendConstant extends DatabendDorisConstant implements DatabendExpression {
+/*
     public boolean isNull() {
         return false;
     }
@@ -29,9 +27,9 @@ public abstract class DatabendConstant implements DatabendExpression {
     public boolean isFloat() {
         return false;
     }
-
+*/
     public abstract DatabendConstant cast(DatabendDataType dataType);
-
+/*
     public boolean asBoolean() {
         throw new UnsupportedOperationException(this.toString());
     }
@@ -47,7 +45,7 @@ public abstract class DatabendConstant implements DatabendExpression {
     public double asFloat() {
         throw new UnsupportedOperationException(this.toString());
     }
-
+*/
     protected Timestamp truncateTimestamp(long val) {
         // Databend supports `date` and `timestamp` type where the year cannot exceed `9999`,
         // the value is truncated to ensure generate legitimate `date` and `timestamp` value.

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -104,6 +104,7 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             this.value = value;
         }
 
+        @Override
         public DatabendConstant isLessThan(DatabendConstant rightVal) {
             if (rightVal.isNull()) {
                 return DatabendConstant.createNullConstant();
@@ -340,23 +341,22 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         }
     }
 
-    public static class DatabendDateConstant extends DatabendConstant {
+    public abstract static class DatabendTemporalConstant extends DatabendConstant {
+        protected String textRepr;
 
-        public String textRepr;
-
-        public DatabendDateConstant(long val) {
+        public DatabendTemporalConstant(long val) {
             Timestamp timestamp = truncateTimestamp(val);
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            SimpleDateFormat dateFormat;
+            if (this instanceof DatabendDateConstant) {
+                dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            } else {
+                dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            }
             textRepr = dateFormat.format(timestamp);
         }
 
         public String getValue() {
             return textRepr;
-        }
-
-        @Override
-        public String toString() {
-            return String.format("DATE '%s'", textRepr);
         }
 
         @Override
@@ -374,26 +374,21 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             return null;
         }
     }
+    public static class DatabendDateConstant extends DatabendTemporalConstant {
 
-    public static class DatabendTimestampConstant extends DatabendConstant {
-
-        public String textRepr;
-
-        public DatabendTimestampConstant(long val) {
-            Timestamp timestamp = truncateTimestamp(val);
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-            textRepr = dateFormat.format(timestamp);
+        public DatabendDateConstant(long val) {
+            super(val);
         }
-
+/*
         public String getValue() {
             return textRepr;
         }
-
+*/
         @Override
         public String toString() {
-            return String.format("TIMESTAMP '%s'", textRepr);
+            return String.format("DATE '%s'", textRepr);
         }
-
+/*
         @Override
         public DatabendConstant cast(DatabendDataType dataType) {
             return null;
@@ -408,6 +403,41 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         public DatabendConstant isLessThan(DatabendConstant rightVal) {
             return null;
         }
+
+ */
+    }
+
+    public static class DatabendTimestampConstant extends DatabendTemporalConstant {
+
+        public DatabendTimestampConstant(long val) {
+            super(val);
+        }
+/*
+        public String getValue() {
+            return textRepr;
+        }
+*/
+        @Override
+        public String toString() {
+            return String.format("TIMESTAMP '%s'", textRepr);
+        }
+/*
+        @Override
+        public DatabendConstant cast(DatabendDataType dataType) {
+            return null;
+        }
+
+        @Override
+        public DatabendConstant isEquals(DatabendConstant rightVal) {
+            return null;
+        }
+
+        @Override
+        public DatabendConstant isLessThan(DatabendConstant rightVal) {
+            return null;
+        }
+
+ */
     }
 
     public static class DatabendBooleanConstant extends DatabendConstant {

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -80,7 +80,7 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         // }
     }
 
-    public static abstract class DatabendNumericConstant<T extends Number> extends DatabendConstant {
+    public abstract static class DatabendNumericConstant<T extends Number> extends DatabendConstant {
         protected final T value;
 
         public DatabendNumericConstant(T value) {

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -7,45 +7,28 @@ import sqlancer.DatabendDorisConstant;
 import sqlancer.databend.DatabendSchema.DatabendDataType;
 
 public abstract class DatabendConstant extends DatabendDorisConstant implements DatabendExpression {
-/*
-    public boolean isNull() {
-        return false;
-    }
-
-    public boolean isInt() {
-        return false;
-    }
-
-    public boolean isBoolean() {
-        return false;
-    }
-
-    public boolean isString() {
-        return false;
-    }
-
-    public boolean isFloat() {
-        return false;
-    }
-*/
+    /*
+     * public boolean isNull() { return false; }
+     *
+     * public boolean isInt() { return false; }
+     *
+     * public boolean isBoolean() { return false; }
+     *
+     * public boolean isString() { return false; }
+     *
+     * public boolean isFloat() { return false; }
+     */
     public abstract DatabendConstant cast(DatabendDataType dataType);
-/*
-    public boolean asBoolean() {
-        throw new UnsupportedOperationException(this.toString());
-    }
 
-    public long asInt() {
-        throw new UnsupportedOperationException(this.toString());
-    }
-
-    public String asString() {
-        throw new UnsupportedOperationException(this.toString());
-    }
-
-    public double asFloat() {
-        throw new UnsupportedOperationException(this.toString());
-    }
-*/
+    /*
+     * public boolean asBoolean() { throw new UnsupportedOperationException(this.toString()); }
+     *
+     * public long asInt() { throw new UnsupportedOperationException(this.toString()); }
+     *
+     * public String asString() { throw new UnsupportedOperationException(this.toString()); }
+     *
+     * public double asFloat() { throw new UnsupportedOperationException(this.toString()); }
+     */
     protected Timestamp truncateTimestamp(long val) {
         // Databend supports `date` and `timestamp` type where the year cannot exceed `9999`,
         // the value is truncated to ensure generate legitimate `date` and `timestamp` value.
@@ -172,20 +155,14 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             }
 
         }
-/*
-        @Override
-        public DatabendConstant isLessThan(DatabendConstant rightVal) {
-            if (rightVal.isNull()) {
-                return DatabendConstant.createNullConstant();
-            } else if (rightVal.isInt()) {
-                return DatabendConstant.createBooleanConstant(value < rightVal.asInt());
-            } else if (rightVal.isFloat()) {
-                return DatabendConstant.createBooleanConstant(value < rightVal.asFloat());
-            } else {
-                throw new AssertionError(rightVal);
-            }
-        }
-*/
+
+        /*
+         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { if (rightVal.isNull()) { return
+         * DatabendConstant.createNullConstant(); } else if (rightVal.isInt()) { return
+         * DatabendConstant.createBooleanConstant(value < rightVal.asInt()); } else if (rightVal.isFloat()) { return
+         * DatabendConstant.createBooleanConstant(value < rightVal.asFloat()); } else { throw new
+         * AssertionError(rightVal); } }
+         */
         @Override
         public DatabendDataType getExpectedType() {
             return DatabendDataType.INT;
@@ -193,7 +170,6 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
     }
 
     public static class DatabendFloatConstant extends DatabendNumericConstant<Double> {
-
 
         public DatabendFloatConstant(double value) {
             super(value);
@@ -244,20 +220,13 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         public DatabendConstant isEquals(DatabendConstant rightVal) {
             return null;
         }
-/*
-        @Override
-        public DatabendConstant isLessThan(DatabendConstant rightVal) {
-            if (rightVal.isNull()) {
-                return DatabendConstant.createNullConstant();
-            } else if (rightVal.isInt()) {
-                return DatabendConstant.createBooleanConstant(value < rightVal.asInt());
-            } else if (rightVal.isFloat()) {
-                return DatabendConstant.createBooleanConstant(value < rightVal.asFloat());
-            } else {
-                throw new AssertionError(rightVal);
-            }
-        }
- */
+        /*
+         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { if (rightVal.isNull()) { return
+         * DatabendConstant.createNullConstant(); } else if (rightVal.isInt()) { return
+         * DatabendConstant.createBooleanConstant(value < rightVal.asInt()); } else if (rightVal.isFloat()) { return
+         * DatabendConstant.createBooleanConstant(value < rightVal.asFloat()); } else { throw new
+         * AssertionError(rightVal); } }
+         */
     }
 
     public static class DatabendStringConstant extends DatabendConstant {
@@ -374,37 +343,28 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             return null;
         }
     }
+
     public static class DatabendDateConstant extends DatabendTemporalConstant {
 
         public DatabendDateConstant(long val) {
             super(val);
         }
-/*
-        public String getValue() {
-            return textRepr;
-        }
-*/
+
+        /*
+         * public String getValue() { return textRepr; }
+         */
         @Override
         public String toString() {
             return String.format("DATE '%s'", textRepr);
         }
-/*
-        @Override
-        public DatabendConstant cast(DatabendDataType dataType) {
-            return null;
-        }
-
-        @Override
-        public DatabendConstant isEquals(DatabendConstant rightVal) {
-            return null;
-        }
-
-        @Override
-        public DatabendConstant isLessThan(DatabendConstant rightVal) {
-            return null;
-        }
-
- */
+        /*
+         * @Override public DatabendConstant cast(DatabendDataType dataType) { return null; }
+         *
+         * @Override public DatabendConstant isEquals(DatabendConstant rightVal) { return null; }
+         *
+         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { return null; }
+         *
+         */
     }
 
     public static class DatabendTimestampConstant extends DatabendTemporalConstant {
@@ -412,32 +372,22 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         public DatabendTimestampConstant(long val) {
             super(val);
         }
-/*
-        public String getValue() {
-            return textRepr;
-        }
-*/
+
+        /*
+         * public String getValue() { return textRepr; }
+         */
         @Override
         public String toString() {
             return String.format("TIMESTAMP '%s'", textRepr);
         }
-/*
-        @Override
-        public DatabendConstant cast(DatabendDataType dataType) {
-            return null;
-        }
-
-        @Override
-        public DatabendConstant isEquals(DatabendConstant rightVal) {
-            return null;
-        }
-
-        @Override
-        public DatabendConstant isLessThan(DatabendConstant rightVal) {
-            return null;
-        }
-
- */
+        /*
+         * @Override public DatabendConstant cast(DatabendDataType dataType) { return null; }
+         *
+         * @Override public DatabendConstant isEquals(DatabendConstant rightVal) { return null; }
+         *
+         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { return null; }
+         *
+         */
     }
 
     public static class DatabendBooleanConstant extends DatabendConstant {

--- a/src/sqlancer/databend/ast/DatabendConstant.java
+++ b/src/sqlancer/databend/ast/DatabendConstant.java
@@ -7,28 +7,9 @@ import sqlancer.DatabendDorisConstant;
 import sqlancer.databend.DatabendSchema.DatabendDataType;
 
 public abstract class DatabendConstant extends DatabendDorisConstant implements DatabendExpression {
-    /*
-     * public boolean isNull() { return false; }
-     *
-     * public boolean isInt() { return false; }
-     *
-     * public boolean isBoolean() { return false; }
-     *
-     * public boolean isString() { return false; }
-     *
-     * public boolean isFloat() { return false; }
-     */
+
     public abstract DatabendConstant cast(DatabendDataType dataType);
 
-    /*
-     * public boolean asBoolean() { throw new UnsupportedOperationException(this.toString()); }
-     *
-     * public long asInt() { throw new UnsupportedOperationException(this.toString()); }
-     *
-     * public String asString() { throw new UnsupportedOperationException(this.toString()); }
-     *
-     * public double asFloat() { throw new UnsupportedOperationException(this.toString()); }
-     */
     protected Timestamp truncateTimestamp(long val) {
         // Databend supports `date` and `timestamp` type where the year cannot exceed `9999`,
         // the value is truncated to ensure generate legitimate `date` and `timestamp` value.
@@ -156,13 +137,6 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
 
         }
 
-        /*
-         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { if (rightVal.isNull()) { return
-         * DatabendConstant.createNullConstant(); } else if (rightVal.isInt()) { return
-         * DatabendConstant.createBooleanConstant(value < rightVal.asInt()); } else if (rightVal.isFloat()) { return
-         * DatabendConstant.createBooleanConstant(value < rightVal.asFloat()); } else { throw new
-         * AssertionError(rightVal); } }
-         */
         @Override
         public DatabendDataType getExpectedType() {
             return DatabendDataType.INT;
@@ -220,13 +194,6 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
         public DatabendConstant isEquals(DatabendConstant rightVal) {
             return null;
         }
-        /*
-         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { if (rightVal.isNull()) { return
-         * DatabendConstant.createNullConstant(); } else if (rightVal.isInt()) { return
-         * DatabendConstant.createBooleanConstant(value < rightVal.asInt()); } else if (rightVal.isFloat()) { return
-         * DatabendConstant.createBooleanConstant(value < rightVal.asFloat()); } else { throw new
-         * AssertionError(rightVal); } }
-         */
     }
 
     public static class DatabendStringConstant extends DatabendConstant {
@@ -350,21 +317,10 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             super(val);
         }
 
-        /*
-         * public String getValue() { return textRepr; }
-         */
         @Override
         public String toString() {
             return String.format("DATE '%s'", textRepr);
         }
-        /*
-         * @Override public DatabendConstant cast(DatabendDataType dataType) { return null; }
-         *
-         * @Override public DatabendConstant isEquals(DatabendConstant rightVal) { return null; }
-         *
-         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { return null; }
-         *
-         */
     }
 
     public static class DatabendTimestampConstant extends DatabendTemporalConstant {
@@ -373,21 +329,10 @@ public abstract class DatabendConstant extends DatabendDorisConstant implements 
             super(val);
         }
 
-        /*
-         * public String getValue() { return textRepr; }
-         */
         @Override
         public String toString() {
             return String.format("TIMESTAMP '%s'", textRepr);
         }
-        /*
-         * @Override public DatabendConstant cast(DatabendDataType dataType) { return null; }
-         *
-         * @Override public DatabendConstant isEquals(DatabendConstant rightVal) { return null; }
-         *
-         * @Override public DatabendConstant isLessThan(DatabendConstant rightVal) { return null; }
-         *
-         */
     }
 
     public static class DatabendBooleanConstant extends DatabendConstant {

--- a/src/sqlancer/doris/ast/DorisConstant.java
+++ b/src/sqlancer/doris/ast/DorisConstant.java
@@ -94,6 +94,23 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         }
     }
 
+    public abstract static class DorisNumericConstant<T extends Number> extends DorisConstant {
+        private final T value;
+
+        public DorisNumericConstant(T value) {
+            this.value = value;
+        }
+
+        public T getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean isNum() {
+            return true;
+        }
+
+    }
     public static class DorisIntConstant extends DorisConstant {
 
         private final long value;
@@ -106,20 +123,24 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public String toString() {
             return String.valueOf(value);
         }
-
+/*
         public long getValue() {
             return value;
         }
+
+ */
 
         @Override
         public boolean isInt() {
             return true;
         }
-
+/*
         @Override
         public boolean isNum() {
             return true;
         }
+
+ */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -196,20 +217,24 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisFloatConstant(double value) {
             this.value = value;
         }
-
+/*
         public double getValue() {
             return value;
         }
+
+ */
 
         @Override
         public boolean isFloat() {
             return true;
         }
-
+/*
         @Override
         public boolean isNum() {
             return true;
         }
+
+ */
 
         @Override
         public String toString() {
@@ -378,16 +403,23 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
 
     }
 
-    public static class DorisDateConstant extends DorisConstant {
-
+    public abstract static class DorisTemporalConstant extends DorisConstant {
         public String textRepr;
 
-        public DorisDateConstant(long val) {
-            textRepr = DorisNumberUtils.timestampToDateText(val);
+        public DorisTemporalConstant(long val) {
+            if (this instanceof DorisDateConstant) {
+                textRepr = DorisNumberUtils.timestampToDateText(val);
+            } else {
+                textRepr = DorisNumberUtils.timestampToDatetimeText(val);
+            }
         }
 
-        public DorisDateConstant(String textRepr) {
+        public DorisTemporalConstant(String textRepr) {
             this.textRepr = textRepr;
+        }
+
+        public DorisTemporalConstant() {
+            textRepr = "CURRENT_TIMESTAMP";
         }
 
         public String getValue() {
@@ -395,14 +427,41 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         }
 
         @Override
+         public String asString() {
+            return textRepr;
+         }
+
+
+    }
+    public static class DorisDateConstant extends DorisTemporalConstant {
+
+        public String textRepr;
+
+        public DorisDateConstant(long val) {
+            super(val);
+        }
+
+        public DorisDateConstant(String textRepr) {
+            super(textRepr);
+        }
+/*
+        public String getValue() {
+            return textRepr;
+        }
+
+ */
+
+        @Override
         public String toString() {
             return String.format("DATE '%s'", textRepr);
         }
-
+/*
         @Override
         public String asString() {
             return textRepr;
         }
+
+ */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -454,35 +513,39 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         }
     }
 
-    public static class DorisDatetimeConstant extends DorisConstant {
+    public static class DorisDatetimeConstant extends DorisTemporalConstant {
 
         public String textRepr;
 
         public DorisDatetimeConstant(long val) {
-            textRepr = DorisNumberUtils.timestampToDatetimeText(val);
+            super(val);
         }
 
         public DorisDatetimeConstant(String textRepr) {
-            this.textRepr = textRepr;
+            super(textRepr);
         }
 
         public DorisDatetimeConstant() {
-            textRepr = "CURRENT_TIMESTAMP";
+            super();
         }
-
+/*
         public String getValue() {
             return textRepr;
         }
+
+ */
 
         @Override
         public String toString() {
             return String.format("TIMESTAMP '%s'", textRepr);
         }
-
+/*
         @Override
         public String asString() {
             return textRepr;
         }
+
+ */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {

--- a/src/sqlancer/doris/ast/DorisConstant.java
+++ b/src/sqlancer/doris/ast/DorisConstant.java
@@ -5,17 +5,7 @@ import sqlancer.doris.DorisSchema.DorisDataType;
 import sqlancer.doris.utils.DorisNumberUtils;
 
 public abstract class DorisConstant extends DatabendDorisConstant implements DorisExpression {
-    /*
-     * public boolean isNull() { return false; }
-     *
-     * public boolean isInt() { return false; }
-     *
-     * public boolean isBoolean() { return false; }
-     *
-     * public boolean isString() { return false; }
-     *
-     * public boolean isFloat() { return false; }
-     */
+
     public boolean isNum() {
         // for INT, FLOAT, BOOLEAN
         return false;
@@ -29,15 +19,6 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         return false;
     }
 
-    /*
-     * public boolean asBoolean() { throw new UnsupportedOperationException(this.toString()); }
-     *
-     * public long asInt() { throw new UnsupportedOperationException(this.toString()); }
-     *
-     * public String asString() { throw new UnsupportedOperationException(this.toString()); }
-     *
-     * public double asFloat() { throw new UnsupportedOperationException(this.toString()); }
-     */
     public abstract DorisConstant cast(DorisDataType dataType);
 
     public abstract DorisConstant valueEquals(DorisConstant rightVal);
@@ -105,19 +86,11 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public String toString() {
             return String.valueOf(value);
         }
-        /*
-         * public long getValue() { return value; }
-         *
-         */
 
         @Override
         public boolean isInt() {
             return true;
         }
-        /*
-         * @Override public boolean isNum() { return true; }
-         *
-         */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -192,19 +165,11 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisFloatConstant(double value) {
             super(value);
         }
-        /*
-         * public double getValue() { return value; }
-         *
-         */
 
         @Override
         public boolean isFloat() {
             return true;
         }
-        /*
-         * @Override public boolean isNum() { return true; }
-         *
-         */
 
         @Override
         public String toString() {
@@ -414,19 +379,11 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisDateConstant(String textRepr) {
             super(textRepr);
         }
-        /*
-         * public String getValue() { return textRepr; }
-         *
-         */
 
         @Override
         public String toString() {
             return String.format("DATE '%s'", textRepr);
         }
-        /*
-         * @Override public String asString() { return textRepr; }
-         *
-         */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -493,19 +450,11 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisDatetimeConstant() {
             super();
         }
-        /*
-         * public String getValue() { return textRepr; }
-         *
-         */
 
         @Override
         public String toString() {
             return String.format("TIMESTAMP '%s'", textRepr);
         }
-        /*
-         * @Override public String asString() { return textRepr; }
-         *
-         */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -597,13 +546,13 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         }
 
         @Override
-        public boolean asBoolean() {
-            return value;
+        public boolean isBoolean() {
+            return true;
         }
 
         @Override
-        public boolean isBoolean() {
-            return true;
+        public boolean asBoolean() {
+            return value;
         }
 
         @Override

--- a/src/sqlancer/doris/ast/DorisConstant.java
+++ b/src/sqlancer/doris/ast/DorisConstant.java
@@ -78,7 +78,7 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
     }
 
     public abstract static class DorisNumericConstant<T extends Number> extends DorisConstant {
-        private final T value;
+        protected final T value;
 
         public DorisNumericConstant(T value) {
             this.value = value;
@@ -95,12 +95,10 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
 
     }
 
-    public static class DorisIntConstant extends DorisConstant {
-
-        private final long value;
+    public static class DorisIntConstant extends DorisNumericConstant<Long> {
 
         public DorisIntConstant(long value) {
-            this.value = value;
+            super(value);
         }
 
         @Override
@@ -189,12 +187,10 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
 
     }
 
-    public static class DorisFloatConstant extends DorisConstant {
-
-        private final double value;
+    public static class DorisFloatConstant extends DorisNumericConstant<Double> {
 
         public DorisFloatConstant(double value) {
-            this.value = value;
+            super(value);
         }
         /*
          * public double getValue() { return value; }

--- a/src/sqlancer/doris/ast/DorisConstant.java
+++ b/src/sqlancer/doris/ast/DorisConstant.java
@@ -1,13 +1,11 @@
 package sqlancer.doris.ast;
 
+import sqlancer.DatabendDorisConstant;
 import sqlancer.doris.DorisSchema.DorisDataType;
 import sqlancer.doris.utils.DorisNumberUtils;
 
-public abstract class DorisConstant implements DorisExpression {
-
-    private DorisConstant() {
-    }
-
+public abstract class DorisConstant extends DatabendDorisConstant implements DorisExpression {
+/*
     public boolean isNull() {
         return false;
     }
@@ -27,7 +25,7 @@ public abstract class DorisConstant implements DorisExpression {
     public boolean isFloat() {
         return false;
     }
-
+*/
     public boolean isNum() {
         // for INT, FLOAT, BOOLEAN
         return false;
@@ -40,7 +38,7 @@ public abstract class DorisConstant implements DorisExpression {
     public boolean isDatetime() {
         return false;
     }
-
+/*
     public boolean asBoolean() {
         throw new UnsupportedOperationException(this.toString());
     }
@@ -56,7 +54,7 @@ public abstract class DorisConstant implements DorisExpression {
     public double asFloat() {
         throw new UnsupportedOperationException(this.toString());
     }
-
+*/
     public abstract DorisConstant cast(DorisDataType dataType);
 
     public abstract DorisConstant valueEquals(DorisConstant rightVal);

--- a/src/sqlancer/doris/ast/DorisConstant.java
+++ b/src/sqlancer/doris/ast/DorisConstant.java
@@ -221,7 +221,7 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisConstant cast(DorisDataType dataType) {
             switch (dataType) {
             case INT:
-                return new DorisIntConstant((long) value);
+                return new DorisIntConstant(value.longValue());
             case FLOAT:
             case DECIMAL:
                 return this;

--- a/src/sqlancer/doris/ast/DorisConstant.java
+++ b/src/sqlancer/doris/ast/DorisConstant.java
@@ -5,27 +5,17 @@ import sqlancer.doris.DorisSchema.DorisDataType;
 import sqlancer.doris.utils.DorisNumberUtils;
 
 public abstract class DorisConstant extends DatabendDorisConstant implements DorisExpression {
-/*
-    public boolean isNull() {
-        return false;
-    }
-
-    public boolean isInt() {
-        return false;
-    }
-
-    public boolean isBoolean() {
-        return false;
-    }
-
-    public boolean isString() {
-        return false;
-    }
-
-    public boolean isFloat() {
-        return false;
-    }
-*/
+    /*
+     * public boolean isNull() { return false; }
+     *
+     * public boolean isInt() { return false; }
+     *
+     * public boolean isBoolean() { return false; }
+     *
+     * public boolean isString() { return false; }
+     *
+     * public boolean isFloat() { return false; }
+     */
     public boolean isNum() {
         // for INT, FLOAT, BOOLEAN
         return false;
@@ -38,23 +28,16 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
     public boolean isDatetime() {
         return false;
     }
-/*
-    public boolean asBoolean() {
-        throw new UnsupportedOperationException(this.toString());
-    }
 
-    public long asInt() {
-        throw new UnsupportedOperationException(this.toString());
-    }
-
-    public String asString() {
-        throw new UnsupportedOperationException(this.toString());
-    }
-
-    public double asFloat() {
-        throw new UnsupportedOperationException(this.toString());
-    }
-*/
+    /*
+     * public boolean asBoolean() { throw new UnsupportedOperationException(this.toString()); }
+     *
+     * public long asInt() { throw new UnsupportedOperationException(this.toString()); }
+     *
+     * public String asString() { throw new UnsupportedOperationException(this.toString()); }
+     *
+     * public double asFloat() { throw new UnsupportedOperationException(this.toString()); }
+     */
     public abstract DorisConstant cast(DorisDataType dataType);
 
     public abstract DorisConstant valueEquals(DorisConstant rightVal);
@@ -111,6 +94,7 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         }
 
     }
+
     public static class DorisIntConstant extends DorisConstant {
 
         private final long value;
@@ -123,24 +107,19 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public String toString() {
             return String.valueOf(value);
         }
-/*
-        public long getValue() {
-            return value;
-        }
-
- */
+        /*
+         * public long getValue() { return value; }
+         *
+         */
 
         @Override
         public boolean isInt() {
             return true;
         }
-/*
-        @Override
-        public boolean isNum() {
-            return true;
-        }
-
- */
+        /*
+         * @Override public boolean isNum() { return true; }
+         *
+         */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -217,24 +196,19 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisFloatConstant(double value) {
             this.value = value;
         }
-/*
-        public double getValue() {
-            return value;
-        }
-
- */
+        /*
+         * public double getValue() { return value; }
+         *
+         */
 
         @Override
         public boolean isFloat() {
             return true;
         }
-/*
-        @Override
-        public boolean isNum() {
-            return true;
-        }
-
- */
+        /*
+         * @Override public boolean isNum() { return true; }
+         *
+         */
 
         @Override
         public String toString() {
@@ -427,12 +401,12 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         }
 
         @Override
-         public String asString() {
+        public String asString() {
             return textRepr;
-         }
-
+        }
 
     }
+
     public static class DorisDateConstant extends DorisTemporalConstant {
 
         public String textRepr;
@@ -444,24 +418,19 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisDateConstant(String textRepr) {
             super(textRepr);
         }
-/*
-        public String getValue() {
-            return textRepr;
-        }
-
- */
+        /*
+         * public String getValue() { return textRepr; }
+         *
+         */
 
         @Override
         public String toString() {
             return String.format("DATE '%s'", textRepr);
         }
-/*
-        @Override
-        public String asString() {
-            return textRepr;
-        }
-
- */
+        /*
+         * @Override public String asString() { return textRepr; }
+         *
+         */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {
@@ -528,24 +497,19 @@ public abstract class DorisConstant extends DatabendDorisConstant implements Dor
         public DorisDatetimeConstant() {
             super();
         }
-/*
-        public String getValue() {
-            return textRepr;
-        }
-
- */
+        /*
+         * public String getValue() { return textRepr; }
+         *
+         */
 
         @Override
         public String toString() {
             return String.format("TIMESTAMP '%s'", textRepr);
         }
-/*
-        @Override
-        public String asString() {
-            return textRepr;
-        }
-
- */
+        /*
+         * @Override public String asString() { return textRepr; }
+         *
+         */
 
         @Override
         public DorisConstant cast(DorisDataType dataType) {

--- a/src/sqlancer/presto/ast/PrestoConstant.java
+++ b/src/sqlancer/presto/ast/PrestoConstant.java
@@ -783,7 +783,6 @@ public abstract class PrestoConstant implements PrestoExpression {
             return String.valueOf(value);
         }
 
-
     }
 
     public static class PrestoArrayConstant extends PrestoConstant {

--- a/src/sqlancer/presto/ast/PrestoConstant.java
+++ b/src/sqlancer/presto/ast/PrestoConstant.java
@@ -764,15 +764,6 @@ public abstract class PrestoConstant implements PrestoExpression {
             this.value = value;
         }
 
-        public boolean getValue() {
-            return value;
-        }
-
-        @Override
-        public String toString() {
-            return String.valueOf(value);
-        }
-
         @Override
         public boolean asBoolean() {
             return value;
@@ -782,6 +773,16 @@ public abstract class PrestoConstant implements PrestoExpression {
         public boolean isBoolean() {
             return true;
         }
+
+        public boolean getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
 
     }
 

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLTableGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLTableGenerator.java
@@ -55,7 +55,7 @@ public class YSQLTableGenerator {
         errors.add("has pseudo-type unknown");
         errors.add("no collation was derived for partition key column");
         errors.add("cannot set colocated true on a non-colocated database");
-        errors.add("Cannot split table that does not have primary key");
+        errors.add("cannot split table that does not have primary key");
         errors.add("inherits from generated column but specifies identity");
         errors.add("inherits from generated column but specifies default");
         YSQLErrors.addCommonExpressionErrors(errors);


### PR DESCRIPTION
Abstracted some common methods from DatabendConstant and DorisConstant such that they share a common logic, this is aimed at reducing code duplication in the codebase.

Certain sub-classes such as the numeric constant classes of these 2 classes also have common code in which they have been abstracted into an intermediate abstract class.

Certain methods within Databend and Doris such as isLessThan() in Databend and cast() in Doris.