### PR TITLE
Build SQLIndexGenerator

### DIFF
--- a/src/sqlancer/SQLIndexGenerator.java
+++ b/src/sqlancer/SQLIndexGenerator.java
@@ -2,7 +2,7 @@ package sqlancer;
 
 import sqlancer.common.query.ExpectedErrors;
 
-public class SQLIndexGenerator {
+public abstract class SQLIndexGenerator {
 
     protected SQLIndexGenerator() {
     }

--- a/src/sqlancer/SQLIndexGenerator.java
+++ b/src/sqlancer/SQLIndexGenerator.java
@@ -1,5 +1,7 @@
 package sqlancer;
 
+import sqlancer.common.query.ExpectedErrors;
+
 public class SQLIndexGenerator {
 
     protected SQLIndexGenerator() {
@@ -7,6 +9,38 @@ public class SQLIndexGenerator {
 
     public enum IndexType {
         BTREE, HASH, GIST, GIN
+    }
+
+    protected static ExpectedErrors generateErrors() {
+        ExpectedErrors errors = new ExpectedErrors();
+
+        errors.add("already contains data"); // CONCURRENT INDEX failed
+        errors.add("You might need to add explicit type casts");
+        errors.add(" collations are not supported"); // TODO check
+        errors.add("because it has pending trigger events");
+        errors.add("could not determine which collation to use for index expression");
+        errors.add("could not determine which collation to use for string comparison");
+        errors.add("is duplicated");
+        errors.add("access method \"gin\" does not support unique indexes");
+        errors.add("access method \"hash\" does not support unique indexes");
+        errors.add("already exists");
+        errors.add("could not create unique index");
+        errors.add("has no default operator class");
+        errors.add("does not support");
+        errors.add("unsupported UNIQUE constraint with partition key definition");
+        errors.add("insufficient columns in UNIQUE constraint definition");
+        errors.add("invalid input syntax for");
+        errors.add("must be type ");
+        errors.add("integer out of range");
+        errors.add("division by zero");
+        errors.add("out of range");
+        errors.add("functions in index predicate must be marked IMMUTABLE");
+        errors.add("functions in index expression must be marked IMMUTABLE");
+        errors.add("result of range difference would not be contiguous");
+        errors.add("which is part of the partition key");
+
+        return errors;
+
     }
 
 }

--- a/src/sqlancer/SQLIndexGenerator.java
+++ b/src/sqlancer/SQLIndexGenerator.java
@@ -1,0 +1,12 @@
+package sqlancer;
+
+public class SQLIndexGenerator {
+
+    protected SQLIndexGenerator() {
+    }
+
+    public enum IndexType {
+        BTREE, HASH, GIST, GIN
+    }
+
+}

--- a/src/sqlancer/materialize/gen/MaterializeIndexGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeIndexGenerator.java
@@ -1,22 +1,19 @@
 package sqlancer.materialize.gen;
 
 import sqlancer.Randomly;
+import sqlancer.SQLIndexGenerator;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.materialize.MaterializeGlobalState;
 import sqlancer.materialize.MaterializeSchema.MaterializeTable;
 
-public final class MaterializeIndexGenerator {
+public final class MaterializeIndexGenerator extends SQLIndexGenerator {
 
     private MaterializeIndexGenerator() {
     }
 
-    public enum IndexType {
-        BTREE, HASH, GIST, GIN
-    }
-
     public static SQLQueryAdapter generate(MaterializeGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
+        ExpectedErrors errors = SQLIndexGenerator.generateErrors();
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE");
         sb.append(" INDEX ");
@@ -49,31 +46,7 @@ public final class MaterializeIndexGenerator {
         }
 
         sb.append(")");
-        errors.add("already contains data"); // CONCURRENT INDEX failed
-        errors.add("You might need to add explicit type casts");
-        errors.add(" collations are not supported");
-        errors.add("because it has pending trigger events");
-        errors.add("could not determine which collation to use for index expression");
-        errors.add("could not determine which collation to use for string comparison");
-        errors.add("is duplicated");
-        errors.add("access method \"gin\" does not support unique indexes");
-        errors.add("access method \"hash\" does not support unique indexes");
-        errors.add("already exists");
-        errors.add("could not create unique index");
-        errors.add("has no default operator class");
-        errors.add("does not support");
         errors.add("does not support casting");
-        errors.add("unsupported UNIQUE constraint with partition key definition");
-        errors.add("insufficient columns in UNIQUE constraint definition");
-        errors.add("invalid input syntax for");
-        errors.add("must be type ");
-        errors.add("integer out of range");
-        errors.add("division by zero");
-        errors.add("out of range");
-        errors.add("functions in index predicate must be marked IMMUTABLE");
-        errors.add("functions in index expression must be marked IMMUTABLE");
-        errors.add("result of range difference would not be contiguous");
-        errors.add("which is part of the partition key");
         MaterializeCommon.addCommonExpressionErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
+import sqlancer.SQLIndexGenerator;
 import sqlancer.common.DBMSCommon;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
@@ -15,13 +16,9 @@ import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresVisitor;
 import sqlancer.postgres.ast.PostgresExpression;
 
-public final class PostgresIndexGenerator {
+public final class PostgresIndexGenerator extends SQLIndexGenerator {
 
     private PostgresIndexGenerator() {
-    }
-
-    public enum IndexType {
-        BTREE, HASH, GIST, GIN
     }
 
     public static SQLQueryAdapter generate(PostgresGlobalState globalState) {

--- a/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
@@ -22,7 +22,7 @@ public final class PostgresIndexGenerator extends SQLIndexGenerator {
     }
 
     public static SQLQueryAdapter generate(PostgresGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
+        ExpectedErrors errors = SQLIndexGenerator.generateErrors();
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE");
         if (Randomly.getBoolean()) {
@@ -107,31 +107,8 @@ public final class PostgresIndexGenerator extends SQLIndexGenerator {
                     .setGlobalState(globalState).generateExpression(PostgresDataType.BOOLEAN);
             sb.append(PostgresVisitor.asString(expr));
         }
-        errors.add("already contains data"); // CONCURRENT INDEX failed
-        errors.add("You might need to add explicit type casts");
-        errors.add(" collations are not supported"); // TODO check
-        errors.add("because it has pending trigger events");
-        errors.add("could not determine which collation to use for index expression");
-        errors.add("could not determine which collation to use for string comparison");
-        errors.add("is duplicated");
-        errors.add("access method \"gin\" does not support unique indexes");
-        errors.add("access method \"hash\" does not support unique indexes");
-        errors.add("already exists");
-        errors.add("could not create unique index");
-        errors.add("has no default operator class");
-        errors.add("does not support");
+
         errors.add("cannot cast");
-        errors.add("unsupported UNIQUE constraint with partition key definition");
-        errors.add("insufficient columns in UNIQUE constraint definition");
-        errors.add("invalid input syntax for");
-        errors.add("must be type ");
-        errors.add("integer out of range");
-        errors.add("division by zero");
-        errors.add("out of range");
-        errors.add("functions in index predicate must be marked IMMUTABLE");
-        errors.add("functions in index expression must be marked IMMUTABLE");
-        errors.add("result of range difference would not be contiguous");
-        errors.add("which is part of the partition key");
         PostgresCommon.addCommonExpressionErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
@@ -24,7 +24,7 @@ public final class YSQLIndexGenerator extends SQLIndexGenerator {
     }
 
     public static SQLQueryAdapter generate(YSQLGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
+        ExpectedErrors errors = SQLIndexGenerator.generateErrors();
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE");
         if (Randomly.getBoolean()) {
@@ -111,17 +111,6 @@ public final class YSQLIndexGenerator extends SQLIndexGenerator {
         errors.add("has no default operator class");
         errors.add("does not support");
         errors.add("cannot cast");
-        errors.add("unsupported UNIQUE constraint with partition key definition");
-        errors.add("insufficient columns in UNIQUE constraint definition");
-        errors.add("invalid input syntax for");
-        errors.add("must be type ");
-        errors.add("integer out of range");
-        errors.add("division by zero");
-        errors.add("out of range");
-        errors.add("functions in index predicate must be marked IMMUTABLE");
-        errors.add("functions in index expression must be marked IMMUTABLE");
-        errors.add("result of range difference would not be contiguous");
-        errors.add("which is part of the partition key");
         YSQLErrors.addCommonExpressionErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
+import sqlancer.SQLIndexGenerator;
 import sqlancer.common.DBMSCommon;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
@@ -17,7 +18,7 @@ import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
 import sqlancer.yugabyte.ysql.YSQLVisitor;
 import sqlancer.yugabyte.ysql.ast.YSQLExpression;
 
-public final class YSQLIndexGenerator {
+public final class YSQLIndexGenerator extends SQLIndexGenerator {
 
     private YSQLIndexGenerator() {
     }
@@ -135,9 +136,4 @@ public final class YSQLIndexGenerator {
             }
         }
     }
-
-    public enum IndexType {
-        BTREE, HASH, GIST, GIN
-    }
-
 }


### PR DESCRIPTION
This PR builds a common abstract class `SQLIndexGenerator`, which is used by `MaterializeIndexGenerator`, `PostgresIndexGenerator` and `YSQLIndexGenerator`
