### PR TITLE
Update SQLDiscardGenerator to extract out more duplicates

### DIFF
--- a/src/sqlancer/SQLDiscardGenerator.java
+++ b/src/sqlancer/SQLDiscardGenerator.java
@@ -1,5 +1,8 @@
 package sqlancer;
 
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+
 public abstract class SQLDiscardGenerator {
 
     protected SQLDiscardGenerator() {
@@ -7,5 +10,24 @@ public abstract class SQLDiscardGenerator {
 
     protected static boolean canDiscardTemporaryTables(String what) {
         return what.contentEquals("TEMPORARY") || what.contentEquals("TEMP") || what.contentEquals("ALL");
+    }
+
+    protected static SQLQueryAdapter create(boolean hasNonTempTables) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DISCARD ");
+        String what;
+        if (hasNonTempTables) {
+            what = Randomly.fromOptions("ALL", "PLANS", "SEQUENCES", "TEMPORARY", "TEMP");
+        } else {
+            what = Randomly.fromOptions("PLANS", "SEQUENCES");
+        }
+        sb.append(what);
+        return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
+
+            @Override
+            public boolean couldAffectSchema() {
+                return canDiscardTemporaryTables(what);
+            }
+        };
     }
 }

--- a/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.postgres.gen;
 
-import sqlancer.Randomly;
 import sqlancer.SQLDiscardGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresTable.TableType;

--- a/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
@@ -14,25 +14,11 @@ public final class PostgresDiscardGenerator extends SQLDiscardGenerator {
     }
 
     public static SQLQueryAdapter create(PostgresGlobalState globalState) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DISCARD ");
         // prevent that DISCARD discards all tables (if they are TEMP tables)
         boolean hasNonTempTables = globalState.getSchema().getDatabaseTables().stream()
                 .anyMatch(t -> t.getTableType() == TableType.STANDARD);
-        String what;
-        if (hasNonTempTables) {
-            what = Randomly.fromOptions("ALL", "PLANS", "SEQUENCES", "TEMPORARY", "TEMP");
-        } else {
-            what = Randomly.fromOptions("PLANS", "SEQUENCES");
-        }
-        sb.append(what);
-        return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
 
-            @Override
-            public boolean couldAffectSchema() {
-                return canDiscardTemporaryTables(what);
-            }
-        };
+        return SQLDiscardGenerator.create(hasNonTempTables);
     }
 
 }

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.yugabyte.ysql.gen;
 
-import sqlancer.Randomly;
 import sqlancer.SQLDiscardGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.yugabyte.ysql.YSQLGlobalState;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable.TableType;

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
@@ -14,25 +14,10 @@ public final class YSQLDiscardGenerator extends SQLDiscardGenerator {
     }
 
     public static SQLQueryAdapter create(YSQLGlobalState globalState) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DISCARD ");
         // prevent that DISCARD discards all tables (if they are TEMP tables)
         boolean hasNonTempTables = globalState.getSchema().getDatabaseTables().stream()
                 .anyMatch(t -> t.getTableType() == TableType.STANDARD);
-        String what;
-        if (hasNonTempTables) {
-            what = Randomly.fromOptions("ALL", "PLANS", "SEQUENCES", "TEMPORARY", "TEMP");
-        } else {
-            what = Randomly.fromOptions("PLANS", "SEQUENCES");
-        }
-        sb.append(what);
-        return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
 
-            @Override
-            public boolean couldAffectSchema() {
-                return canDiscardTemporaryTables(what);
-            }
-        };
+        return SQLDiscardGenerator.create(hasNonTempTables);
     }
-
 }


### PR DESCRIPTION
Extract out the `create` feature that is used by `Postgres` and `YSQL`